### PR TITLE
Store server settings in DB

### DIFF
--- a/SFServer.API/Controllers/ServerSettingsController.cs
+++ b/SFServer.API/Controllers/ServerSettingsController.cs
@@ -1,0 +1,50 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using SFServer.API.Data;
+using SFServer.Shared.Server.Settings;
+
+namespace SFServer.API.Controllers
+{
+    [ApiController]
+    [Route("[controller]")]
+    [Authorize(Roles = "Admin")]
+    public class ServerSettingsController : ControllerBase
+    {
+        private readonly DatabseContext _db;
+        public ServerSettingsController(DatabseContext db)
+        {
+            _db = db;
+        }
+
+        [HttpGet]
+        [AllowAnonymous]
+        public async Task<IActionResult> GetSettings()
+        {
+            var settings = await _db.ServerSettings.FirstOrDefaultAsync();
+            if (settings == null)
+                return NotFound();
+            return Ok(settings);
+        }
+
+        [HttpPut]
+        public async Task<IActionResult> UpdateSettings([FromBody] ServerSettings updated)
+        {
+            var existing = await _db.ServerSettings.FirstOrDefaultAsync();
+            if (existing == null)
+            {
+                updated.Id = Guid.NewGuid();
+                _db.ServerSettings.Add(updated);
+            }
+            else
+            {
+                existing.ServerCopyright = updated.ServerCopyright;
+                existing.GoogleClientId = updated.GoogleClientId;
+                existing.GoogleClientSecret = updated.GoogleClientSecret;
+            }
+
+            await _db.SaveChangesAsync();
+            return NoContent();
+        }
+    }
+}

--- a/SFServer.API/Data/DatabseContext.cs
+++ b/SFServer.API/Data/DatabseContext.cs
@@ -4,6 +4,7 @@ using SFServer.Shared.Server.UserProfile;
 using SFServer.Shared.Server.Wallet;
 using SFServer.Shared.Server.Inventory;
 using SFServer.Shared.Server.Session;
+using SFServer.Shared.Server.Settings;
 
 namespace SFServer.API.Data
 {
@@ -23,6 +24,8 @@ namespace SFServer.API.Data
         public DbSet<PlayerInventoryItem> PlayerInventoryItems { get; set; }
 
         public DbSet<UserSession> UserSessions { get; set; }
+
+        public DbSet<ServerSettings> ServerSettings { get; set; }
 
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)

--- a/SFServer.API/Migrations/20250701001722_AddServerSettings.Designer.cs
+++ b/SFServer.API/Migrations/20250701001722_AddServerSettings.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SFServer.API.Data;
@@ -12,9 +13,11 @@ using SFServer.API.Data;
 namespace SFServer.API.Migrations
 {
     [DbContext(typeof(DatabseContext))]
-    partial class UserProfilesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250701001722_AddServerSettings")]
+    partial class AddServerSettings
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/SFServer.API/Migrations/20250701001722_AddServerSettings.cs
+++ b/SFServer.API/Migrations/20250701001722_AddServerSettings.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SFServer.API.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddServerSettings : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ServerSettings",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    ServerCopyright = table.Column<string>(type: "text", nullable: true),
+                    GoogleClientId = table.Column<string>(type: "text", nullable: true),
+                    GoogleClientSecret = table.Column<string>(type: "text", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ServerSettings", x => x.Id);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ServerSettings");
+        }
+    }
+}

--- a/SFServer.API/Program.cs
+++ b/SFServer.API/Program.cs
@@ -152,6 +152,21 @@ using (var scope = app.Services.CreateScope())
     {
         Console.WriteLine($"ℹ️ Admin user '{adminUsername}' already exists.");
     }
+
+    // Seed server settings from environment variables if not present
+    if (!context.ServerSettings.Any())
+    {
+        var settings = new SFServer.Shared.Server.Settings.ServerSettings
+        {
+            Id = Guid.NewGuid(),
+            ServerCopyright = config["SERVER_COPYRIGHT"] ?? string.Empty,
+            GoogleClientId = config["GOOGLE_CLIENT_ID"] ?? string.Empty,
+            GoogleClientSecret = config["GOOGLE_CLIENT_SECRET"] ?? string.Empty
+        };
+        context.ServerSettings.Add(settings);
+        context.SaveChanges();
+        Console.WriteLine("✅ Server settings created from environment.");
+    }
 }
 
 app.UseCors("AllowAll");

--- a/SFServer.API/Services/InventoryService.cs
+++ b/SFServer.API/Services/InventoryService.cs
@@ -15,7 +15,7 @@ public class InventoryService
 
     public Task<List<InventoryItem>> GetItemsAsync() => _db.InventoryItems.ToListAsync();
 
-    public Task<InventoryItem?> GetItemAsync(Guid id) => _db.InventoryItems.FindAsync(id).AsTask();
+    public Task<InventoryItem> GetItemAsync(Guid id) => _db.InventoryItems.FindAsync(id).AsTask();
 
     public async Task<InventoryItem> CreateItemAsync(InventoryItem item)
     {

--- a/SFServer.Shared/Server/Settings/ServerSettings.cs
+++ b/SFServer.Shared/Server/Settings/ServerSettings.cs
@@ -1,0 +1,14 @@
+using System;
+using MemoryPack;
+
+namespace SFServer.Shared.Server.Settings
+{
+    [MemoryPackable]
+    public partial class ServerSettings
+    {
+        public Guid Id { get; set; }
+        public string ServerCopyright { get; set; } = string.Empty;
+        public string GoogleClientId { get; set; } = string.Empty;
+        public string GoogleClientSecret { get; set; } = string.Empty;
+    }
+}

--- a/SFServer.UI/Controllers/AccountController.cs
+++ b/SFServer.UI/Controllers/AccountController.cs
@@ -21,7 +21,7 @@ public class AccountController : Controller
     [HttpGet]
     public IActionResult Login(string returnUrl = null)
     {
-        return View(new LoginViewModel { ReturnUrl = returnUrl });
+        return View(new LoginViewModel { ReturnUrl = returnUrl ?? string.Empty });
     }
 
     [HttpPost]

--- a/SFServer.UI/Controllers/ServerSettingsController.cs
+++ b/SFServer.UI/Controllers/ServerSettingsController.cs
@@ -1,14 +1,74 @@
-﻿using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using SFServer.Shared.Server.Settings;
+using SFServer.UI.Models;
 
 namespace SFServer.UI.Controllers
 {
     [Authorize(Roles = "Admin")]
     public class ServerSettingsController : Controller
     {
-        public IActionResult Index()
+        private readonly IConfiguration _configuration;
+        private readonly ServerSettingsService _service;
+        public ServerSettingsController(IConfiguration configuration, ServerSettingsService service)
         {
-            return View();
+            _configuration = configuration;
+            _service = service;
+        }
+
+        private HttpClient GetAuthenticatedHttpClient()
+        {
+            var client = new HttpClient { BaseAddress = new Uri(_configuration["API_BASE_URL"]) };
+            var jwtToken = User.Claims.FirstOrDefault(c => c.Type == "JwtToken")?.Value;
+            if (!string.IsNullOrEmpty(jwtToken))
+            {
+                client.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", jwtToken);
+            }
+            return client;
+        }
+
+        public async Task<IActionResult> Index()
+        {
+            using var client = GetAuthenticatedHttpClient();
+            var settings = await client.GetFromMessagePackAsync<ServerSettings>("ServerSettings");
+            if (settings != null)
+                _service.UpdateCache(settings);
+            var vm = new ServerSettingsViewModel
+            {
+                Id = settings.Id,
+                ServerCopyright = settings.ServerCopyright,
+                GoogleClientId = settings.GoogleClientId,
+                GoogleClientSecret = settings.GoogleClientSecret
+            };
+            return View(vm);
+        }
+
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> Index(ServerSettingsViewModel model)
+        {
+            if (!ModelState.IsValid)
+                return View(model);
+
+            using var client = GetAuthenticatedHttpClient();
+            var payload = new ServerSettings
+            {
+                Id = model.Id,
+                ServerCopyright = model.ServerCopyright,
+                GoogleClientId = model.GoogleClientId,
+                GoogleClientSecret = model.GoogleClientSecret
+            };
+            var response = await client.PutAsMessagePackAsync("ServerSettings", payload);
+            if (!response.IsSuccessStatusCode)
+            {
+                TempData["Error"] = "Failed to save settings.";
+            }
+            else
+            {
+                TempData["Success"] = "Settings saved.";
+                _service.UpdateCache(payload);
+            }
+            return RedirectToAction("Index");
         }
     }
 }

--- a/SFServer.UI/Models/ServerSettingsViewModel.cs
+++ b/SFServer.UI/Models/ServerSettingsViewModel.cs
@@ -1,0 +1,17 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace SFServer.UI.Models;
+
+public class ServerSettingsViewModel
+{
+    public Guid Id { get; set; }
+
+    [Display(Name = "Copyright")]
+    public string ServerCopyright { get; set; } = string.Empty;
+
+    [Display(Name = "Google Client ID")]
+    public string GoogleClientId { get; set; } = string.Empty;
+
+    [Display(Name = "Google Client Secret")]
+    public string GoogleClientSecret { get; set; } = string.Empty;
+}

--- a/SFServer.UI/Program.cs
+++ b/SFServer.UI/Program.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Mvc.Authorization;
+using SFServer.UI;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -25,6 +26,12 @@ builder.Services.AddControllersWithViews(options =>
     options.Filters.Add(new AuthorizeFilter());
 });
 builder.Services.AddRazorPages();
+
+builder.Services.AddHttpClient("api", c =>
+{
+    c.BaseAddress = new Uri(builder.Configuration["API_BASE_URL"]);
+});
+builder.Services.AddSingleton<ServerSettingsService>();
 
 var app = builder.Build();
 

--- a/SFServer.UI/ServerSettingsService.cs
+++ b/SFServer.UI/ServerSettingsService.cs
@@ -1,0 +1,30 @@
+using SFServer.Shared.Server.Settings;
+
+namespace SFServer.UI;
+
+public class ServerSettingsService
+{
+    private readonly IHttpClientFactory _factory;
+    private readonly IConfiguration _configuration;
+    private ServerSettings? _cached;
+
+    public ServerSettingsService(IHttpClientFactory factory, IConfiguration configuration)
+    {
+        _factory = factory;
+        _configuration = configuration;
+    }
+
+    public async Task<ServerSettings?> GetSettingsAsync()
+    {
+        if (_cached != null)
+            return _cached;
+        var client = _factory.CreateClient("api");
+        _cached = await client.GetFromMessagePackAsync<ServerSettings>("ServerSettings");
+        return _cached;
+    }
+
+    public void UpdateCache(ServerSettings settings)
+    {
+        _cached = settings;
+    }
+}

--- a/SFServer.UI/Views/ServerSettings/Index.cshtml
+++ b/SFServer.UI/Views/ServerSettings/Index.cshtml
@@ -1,6 +1,37 @@
-﻿@{
+@model SFServer.UI.Models.ServerSettingsViewModel
+@{
     ViewData["Title"] = "Server Settings";
 }
 
 <h1>Server Settings</h1>
-<p>This page is under construction.</p>
+
+@if (TempData["Success"] != null)
+{
+    <div class="alert alert-success">@TempData["Success"]</div>
+}
+@if (TempData["Error"] != null)
+{
+    <div class="alert alert-danger">@TempData["Error"]</div>
+}
+
+<form asp-action="Index" method="post">
+    @Html.AntiForgeryToken()
+    <input type="hidden" asp-for="Id" />
+    <div class="mb-3">
+        <label asp-for="ServerCopyright" class="form-label"></label>
+        <input asp-for="ServerCopyright" class="form-control" />
+    </div>
+    <div class="mb-3">
+        <label asp-for="GoogleClientId" class="form-label"></label>
+        <input asp-for="GoogleClientId" class="form-control" />
+    </div>
+    <div class="mb-3">
+        <label asp-for="GoogleClientSecret" class="form-label"></label>
+        <input asp-for="GoogleClientSecret" class="form-control" />
+    </div>
+    <button type="submit" class="btn btn-primary">Save</button>
+</form>
+
+@section Scripts {
+    @{ await Html.RenderPartialAsync("_ValidationScriptsPartial"); }
+}

--- a/SFServer.UI/Views/Shared/_Layout.cshtml
+++ b/SFServer.UI/Views/Shared/_Layout.cshtml
@@ -1,6 +1,7 @@
-﻿@using Microsoft.AspNetCore.Mvc.TagHelpers
+@using Microsoft.AspNetCore.Mvc.TagHelpers
 @using SFServer.Shared.Server.UserProfile
 @inject IConfiguration Configuration
+@using SFServer.UI
 
 <!DOCTYPE html>
 <html lang="en" data-bs-theme="light">
@@ -120,9 +121,13 @@
     </main>
 </div>
 
+@inject ServerSettingsService SettingsService
+@{
+    var settings = await SettingsService.GetSettingsAsync();
+}
 <footer class="footer border-top text-body-secondary bg-body-tertiary">
     <div class="container d-flex justify-content-between align-items-center flex-wrap py-3">
-        <span>@Configuration["SERVER_COPYRIGHT"]</span>
+        <span>@settings?.ServerCopyright</span>
 
         @if (User.IsInRole("Admin"))
         {


### PR DESCRIPTION
## Summary
- add `ServerSettings` entity and EF migration
- seed and update settings from environment variables
- expose REST API to read/update server settings
- create UI form for editing server settings
- cache settings in UI layout and update as needed

## Testing
- `dotnet build SFServer.sln`

------
https://chatgpt.com/codex/tasks/task_e_6863285472248323a3b6a8470f467b77