### PR TITLE
Improve UserProfiles pagination display

### DIFF
--- a/SFServer.UI/Controllers/UserProfilesController.cs
+++ b/SFServer.UI/Controllers/UserProfilesController.cs
@@ -83,6 +83,8 @@ namespace SFServer.UI.Controllers
                     Users = pagedProfiles,
                     CurrentPage = page,
                     TotalPages = totalPages,
+                    TotalCount = totalProfiles,
+                    PageSize = pageSize,
                     SearchQuery = search,
                     SortColumn = sortColumn,
                     SortOrder = sortOrder

--- a/SFServer.UI/Controllers/UserProfilesController.cs
+++ b/SFServer.UI/Controllers/UserProfilesController.cs
@@ -40,11 +40,16 @@ namespace SFServer.UI.Controllers
             return client;
         }
 
-        public async Task<IActionResult> Index(int page = 1, string search = "", string sortColumn = "Id", string sortOrder = "asc")
+        public async Task<IActionResult> Index(int page = 1, int pageSize = 20, string search = "", string sortColumn = "Id", string sortOrder = "asc")
         {
             try
             {
                 using var client = GetAuthenticatedHttpClient();
+
+                if (pageSize <= 0)
+                {
+                    pageSize = 20;
+                }
 
                 // Retrieve profiles using MessagePack.
                 var profiles = await client.GetFromMessagePackAsync<List<UserProfile>>("UserProfiles");
@@ -73,7 +78,6 @@ namespace SFServer.UI.Controllers
                 };
 
                 // Pagination logic.
-                int pageSize = 20;
                 int totalProfiles = profiles.Count;
                 int totalPages = (int)Math.Ceiling(totalProfiles / (double)pageSize);
                 var pagedProfiles = profiles.Skip((page - 1) * pageSize).Take(pageSize).ToList();

--- a/SFServer.UI/Models/UserProfiles/UserProfilesIndexViewModel.cs
+++ b/SFServer.UI/Models/UserProfiles/UserProfilesIndexViewModel.cs
@@ -8,8 +8,10 @@ namespace SFServer.UI.Models.UserProfiles
         public List<UserProfile> Users { get; set; } = new();
         public int CurrentPage { get; set; }
         public int TotalPages { get; set; }
+        public int TotalCount { get; set; }
+        public int PageSize { get; set; }
         public string SearchQuery { get; set; } = string.Empty;
-        
+
         public string SortColumn { get; set; } = "Username";
         public string SortOrder { get; set; } = "desc";
     }

--- a/SFServer.UI/Views/UserProfiles/Index.cshtml
+++ b/SFServer.UI/Views/UserProfiles/Index.cshtml
@@ -131,9 +131,9 @@
             <input type="hidden" name="sortOrder" value="@Model.SortOrder" />
             <input type="hidden" name="page" value="1" />
             <select name="pageSize" class="form-select form-select-sm" onchange="this.form.submit()">
-                <option value="10" @(Model.PageSize == 10 ? "selected" : "")>10</option>
-                <option value="20" @(Model.PageSize == 20 ? "selected" : "")>20</option>
-                <option value="50" @(Model.PageSize == 50 ? "selected" : "")>50</option>
+                <option value="10" selected="@(Model.PageSize == 10 ? "selected" : null)">10</option>
+                <option value="20" selected="@(Model.PageSize == 20 ? "selected" : null)">20</option>
+                <option value="50" selected="@(Model.PageSize == 50 ? "selected" : null)">50</option>
             </select>
         </form>
 

--- a/SFServer.UI/Views/UserProfiles/Index.cshtml
+++ b/SFServer.UI/Views/UserProfiles/Index.cshtml
@@ -13,7 +13,7 @@
     {
         // If the column is the current sort column, toggle the order; otherwise default to ascending.
         string order = Model.SortColumn.Equals(column, StringComparison.OrdinalIgnoreCase) ? ToggleSortOrder(Model.SortOrder) : "asc";
-        return Url.Action("Index", new { page = Model.CurrentPage, search = Model.SearchQuery, sortColumn = column, sortOrder = order });
+        return Url.Action("Index", new { page = Model.CurrentPage, search = Model.SearchQuery, pageSize = Model.PageSize, sortColumn = column, sortOrder = order });
     }
 }
 
@@ -23,6 +23,9 @@
 <form method="get" asp-action="Index" class="mb-3">
     <div class="input-group">
         <input type="text" name="search" value="@Model.SearchQuery" class="form-control" placeholder="Search users..." />
+        <input type="hidden" name="pageSize" value="@Model.PageSize" />
+        <input type="hidden" name="sortColumn" value="@Model.SortColumn" />
+        <input type="hidden" name="sortOrder" value="@Model.SortOrder" />
         <button type="submit" class="btn btn-outline-secondary">Search</button>
     </div>
 </form>
@@ -121,20 +124,32 @@
 
 <!-- Pagination Controls -->
 <nav aria-label="User profiles pagination" class="mt-3">
-    <div class="d-flex justify-content-center align-items-center">
-        <span class="me-3">
+    <div class="d-flex justify-content-center align-items-center gap-3 flex-wrap">
+        <form method="get" class="d-flex align-items-center">
+            <input type="hidden" name="search" value="@Model.SearchQuery" />
+            <input type="hidden" name="sortColumn" value="@Model.SortColumn" />
+            <input type="hidden" name="sortOrder" value="@Model.SortOrder" />
+            <input type="hidden" name="page" value="1" />
+            <select name="pageSize" class="form-select form-select-sm" onchange="this.form.submit()">
+                <option value="10" @(Model.PageSize == 10 ? "selected" : "")>10</option>
+                <option value="20" @(Model.PageSize == 20 ? "selected" : "")>20</option>
+                <option value="50" @(Model.PageSize == 50 ? "selected" : "")>50</option>
+            </select>
+        </form>
+
+        <span class="me-2">
             @{int startItem = (Model.CurrentPage - 1) * Model.PageSize + 1;}
             @{int endItem = Math.Min(Model.CurrentPage * Model.PageSize, Model.TotalCount);}
             @startItem-@endItem of @Model.TotalCount
         </span>
         <ul class="pagination mb-0">
             <li class="page-item @(Model.CurrentPage == 1 ? "disabled" : "")">
-                <a class="page-link" asp-action="Index" asp-route-page="@(Model.CurrentPage - 1)" asp-route-search="@Model.SearchQuery" asp-route-sortColumn="@Model.SortColumn" asp-route-sortOrder="@Model.SortOrder" aria-label="Previous">
+                <a class="page-link" asp-action="Index" asp-route-page="@(Model.CurrentPage - 1)" asp-route-search="@Model.SearchQuery" asp-route-sortColumn="@Model.SortColumn" asp-route-sortOrder="@Model.SortOrder" asp-route-pageSize="@Model.PageSize" aria-label="Previous">
                     <span aria-hidden="true"><i class="bi bi-chevron-left"></i></span>
                 </a>
             </li>
             <li class="page-item @(Model.CurrentPage == Model.TotalPages ? "disabled" : "")">
-                <a class="page-link" asp-action="Index" asp-route-page="@(Model.CurrentPage + 1)" asp-route-search="@Model.SearchQuery" asp-route-sortColumn="@Model.SortColumn" asp-route-sortOrder="@Model.SortOrder" aria-label="Next">
+                <a class="page-link" asp-action="Index" asp-route-page="@(Model.CurrentPage + 1)" asp-route-search="@Model.SearchQuery" asp-route-sortColumn="@Model.SortColumn" asp-route-sortOrder="@Model.SortOrder" asp-route-pageSize="@Model.PageSize" aria-label="Next">
                     <span aria-hidden="true"><i class="bi bi-chevron-right"></i></span>
                 </a>
             </li>

--- a/SFServer.UI/Views/UserProfiles/Index.cshtml
+++ b/SFServer.UI/Views/UserProfiles/Index.cshtml
@@ -120,81 +120,24 @@
 </div>
 
 <!-- Pagination Controls -->
-<nav aria-label="User profiles pagination">
-    <ul class="pagination justify-content-center mt-3">
-        @if (Model.CurrentPage > 1)
-        {
-            <li class="page-item">
-                <a class="page-link" asp-action="Index" asp-route-page="@(Model.CurrentPage - 1)" asp-route-search="@Model.SearchQuery" asp-route-sortColumn="@Model.SortColumn" asp-route-sortOrder="@Model.SortOrder">Previous</a>
+<nav aria-label="User profiles pagination" class="mt-3">
+    <div class="d-flex justify-content-center align-items-center">
+        <span class="me-3">
+            @{int startItem = (Model.CurrentPage - 1) * Model.PageSize + 1;}
+            @{int endItem = Math.Min(Model.CurrentPage * Model.PageSize, Model.TotalCount);}
+            @startItem-@endItem of @Model.TotalCount
+        </span>
+        <ul class="pagination mb-0">
+            <li class="page-item @(Model.CurrentPage == 1 ? "disabled" : "")">
+                <a class="page-link" asp-action="Index" asp-route-page="@(Model.CurrentPage - 1)" asp-route-search="@Model.SearchQuery" asp-route-sortColumn="@Model.SortColumn" asp-route-sortOrder="@Model.SortOrder" aria-label="Previous">
+                    <span aria-hidden="true"><i class="bi bi-chevron-left"></i></span>
+                </a>
             </li>
-        }
-        else
-        {
-            <li class="page-item disabled"><span class="page-link">Previous</span></li>
-        }
-
-        @{
-            int startPage = Math.Max(1, Model.CurrentPage - 2);
-            int endPage = Math.Min(Model.TotalPages, Model.CurrentPage + 2);
-        }
-
-        @if (startPage > 1)
-        {
-            <li class="page-item @(Model.CurrentPage == 1 ? "active" : "")">
-                @if(Model.CurrentPage == 1)
-                {
-                    <span class="page-link">1</span>
-                }
-                else
-                {
-                    <a class="page-link" asp-action="Index" asp-route-page="1" asp-route-search="@Model.SearchQuery" asp-route-sortColumn="@Model.SortColumn" asp-route-sortOrder="@Model.SortOrder">1</a>
-                }
+            <li class="page-item @(Model.CurrentPage == Model.TotalPages ? "disabled" : "")">
+                <a class="page-link" asp-action="Index" asp-route-page="@(Model.CurrentPage + 1)" asp-route-search="@Model.SearchQuery" asp-route-sortColumn="@Model.SortColumn" asp-route-sortOrder="@Model.SortOrder" aria-label="Next">
+                    <span aria-hidden="true"><i class="bi bi-chevron-right"></i></span>
+                </a>
             </li>
-            @if (startPage > 2)
-            {
-                <li class="page-item disabled"><span class="page-link">…</span></li>
-            }
-        }
-
-        @for (int i = startPage; i <= endPage; i++)
-        {
-            if (i == Model.CurrentPage)
-            {
-                <li class="page-item active"><span class="page-link">@i</span></li>
-            }
-            else
-            {
-                <li class="page-item"><a class="page-link" asp-action="Index" asp-route-page="@i" asp-route-search="@Model.SearchQuery" asp-route-sortColumn="@Model.SortColumn" asp-route-sortOrder="@Model.SortOrder">@i</a></li>
-            }
-        }
-
-        @if (endPage < Model.TotalPages)
-        {
-            @if (endPage < Model.TotalPages - 1)
-            {
-                <li class="page-item disabled"><span class="page-link">…</span></li>
-            }
-            <li class="page-item @(Model.CurrentPage == Model.TotalPages ? "active" : "")">
-                @if(Model.CurrentPage == Model.TotalPages)
-                {
-                    <span class="page-link">@Model.TotalPages</span>
-                }
-                else
-                {
-                    <a class="page-link" asp-action="Index" asp-route-page="@Model.TotalPages" asp-route-search="@Model.SearchQuery" asp-route-sortColumn="@Model.SortColumn" asp-route-sortOrder="@Model.SortOrder">@Model.TotalPages</a>
-                }
-            </li>
-        }
-
-        @if (Model.CurrentPage < Model.TotalPages)
-        {
-            <li class="page-item">
-                <a class="page-link" asp-action="Index" asp-route-page="@(Model.CurrentPage + 1)" asp-route-search="@Model.SearchQuery" asp-route-sortColumn="@Model.SortColumn" asp-route-sortOrder="@Model.SortOrder">Next</a>
-            </li>
-        }
-        else
-        {
-            <li class="page-item disabled"><span class="page-link">Next</span></li>
-        }
-    </ul>
+        </ul>
+    </div>
 </nav>

--- a/SFServer.UI/Views/UserProfiles/Index.cshtml
+++ b/SFServer.UI/Views/UserProfiles/Index.cshtml
@@ -133,20 +133,57 @@
             <li class="page-item disabled"><span class="page-link">Previous</span></li>
         }
 
-        @for (int i = 1; i <= Model.TotalPages; i++)
+        @{
+            int startPage = Math.Max(1, Model.CurrentPage - 2);
+            int endPage = Math.Min(Model.TotalPages, Model.CurrentPage + 2);
+        }
+
+        @if (startPage > 1)
+        {
+            <li class="page-item @(Model.CurrentPage == 1 ? "active" : "")">
+                @if(Model.CurrentPage == 1)
+                {
+                    <span class="page-link">1</span>
+                }
+                else
+                {
+                    <a class="page-link" asp-action="Index" asp-route-page="1" asp-route-search="@Model.SearchQuery" asp-route-sortColumn="@Model.SortColumn" asp-route-sortOrder="@Model.SortOrder">1</a>
+                }
+            </li>
+            @if (startPage > 2)
+            {
+                <li class="page-item disabled"><span class="page-link">…</span></li>
+            }
+        }
+
+        @for (int i = startPage; i <= endPage; i++)
         {
             if (i == Model.CurrentPage)
             {
-                <li class="page-item active">
-                    <span class="page-link">@i</span>
-                </li>
+                <li class="page-item active"><span class="page-link">@i</span></li>
             }
             else
             {
-                <li class="page-item">
-                    <a class="page-link" asp-action="Index" asp-route-page="@i" asp-route-search="@Model.SearchQuery" asp-route-sortColumn="@Model.SortColumn" asp-route-sortOrder="@Model.SortOrder">@i</a>
-                </li>
+                <li class="page-item"><a class="page-link" asp-action="Index" asp-route-page="@i" asp-route-search="@Model.SearchQuery" asp-route-sortColumn="@Model.SortColumn" asp-route-sortOrder="@Model.SortOrder">@i</a></li>
             }
+        }
+
+        @if (endPage < Model.TotalPages)
+        {
+            @if (endPage < Model.TotalPages - 1)
+            {
+                <li class="page-item disabled"><span class="page-link">…</span></li>
+            }
+            <li class="page-item @(Model.CurrentPage == Model.TotalPages ? "active" : "")">
+                @if(Model.CurrentPage == Model.TotalPages)
+                {
+                    <span class="page-link">@Model.TotalPages</span>
+                }
+                else
+                {
+                    <a class="page-link" asp-action="Index" asp-route-page="@Model.TotalPages" asp-route-search="@Model.SearchQuery" asp-route-sortColumn="@Model.SortColumn" asp-route-sortOrder="@Model.SortOrder">@Model.TotalPages</a>
+                }
+            </li>
         }
 
         @if (Model.CurrentPage < Model.TotalPages)


### PR DESCRIPTION
## Summary
- truncate the UserProfiles pagination controls with ellipses

## Testing
- `dotnet test SFServer.sln -v q` *(fails: domain not in allowlist)*

------
https://chatgpt.com/codex/tasks/task_e_686ac889fc3083238973559bee1be5fd