### PR TITLE
Add editable server title setting

### DIFF
--- a/SFServer.API/Controllers/ServerSettingsController.cs
+++ b/SFServer.API/Controllers/ServerSettingsController.cs
@@ -35,6 +35,7 @@ namespace SFServer.API.Controllers {
             }
             else
             {
+                existing.ServerTitle = updated.ServerTitle;
                 existing.ServerCopyright = updated.ServerCopyright;
                 existing.GoogleClientId = updated.GoogleClientId;
                 existing.GoogleClientSecret = updated.GoogleClientSecret;

--- a/SFServer.API/Migrations/20250704123000_AddServerTitle.Designer.cs
+++ b/SFServer.API/Migrations/20250704123000_AddServerTitle.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SFServer.API.Data;
@@ -12,9 +13,11 @@ using SFServer.API.Data;
 namespace SFServer.API.Migrations
 {
     [DbContext(typeof(DatabseContext))]
-    partial class UserProfilesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250704123000_AddServerTitle")]
+    partial class AddServerTitle
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/SFServer.API/Migrations/20250704123000_AddServerTitle.cs
+++ b/SFServer.API/Migrations/20250704123000_AddServerTitle.cs
@@ -1,0 +1,28 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SFServer.API.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddServerTitle : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "ServerTitle",
+                table: "ServerSettings",
+                type: "text",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ServerTitle",
+                table: "ServerSettings");
+        }
+    }
+}

--- a/SFServer.API/Program.cs
+++ b/SFServer.API/Program.cs
@@ -160,6 +160,7 @@ using (var scope = app.Services.CreateScope())
         var settings = new SFServer.Shared.Server.Settings.ServerSettings
         {
             Id = Guid.NewGuid(),
+            ServerTitle = config["SERVER_TITLE"] ?? string.Empty,
             ServerCopyright = config["SERVER_COPYRIGHT"] ?? string.Empty,
             GoogleClientId = config["GOOGLE_CLIENT_ID"] ?? string.Empty,
             ClickHouseConnection = config["CLICKHOUSE_CONNECTION"] ?? string.Empty,

--- a/SFServer.Shared/Server/Settings/ServerSettings.cs
+++ b/SFServer.Shared/Server/Settings/ServerSettings.cs
@@ -7,6 +7,7 @@ namespace SFServer.Shared.Server.Settings
     public partial class ServerSettings
     {
         public Guid Id { get; set; }
+        public string ServerTitle { get; set; } = string.Empty;
         public string ServerCopyright { get; set; } = string.Empty;
         public string GoogleClientId { get; set; } = string.Empty;
         public string ClickHouseConnection { get; set; } = string.Empty;

--- a/SFServer.UI/Controllers/ServerSettingsController.cs
+++ b/SFServer.UI/Controllers/ServerSettingsController.cs
@@ -43,6 +43,7 @@ namespace SFServer.UI.Controllers
             var vm = new ServerSettingsViewModel
             {
                 Id = settings.Id,
+                ServerTitle = settings.ServerTitle,
                 ServerCopyright = settings.ServerCopyright,
                 GoogleClientId = settings.GoogleClientId,
                 ClickHouseConnection = settings.ClickHouseConnection,
@@ -63,6 +64,7 @@ namespace SFServer.UI.Controllers
             var payload = new ServerSettings
             {
                 Id = model.Id,
+                ServerTitle = model.ServerTitle,
                 ServerCopyright = model.ServerCopyright,
                 GoogleClientId = model.GoogleClientId,
                 GoogleClientSecret = model.GoogleClientSecret,

--- a/SFServer.UI/Models/ServerSettingsViewModel.cs
+++ b/SFServer.UI/Models/ServerSettingsViewModel.cs
@@ -7,6 +7,9 @@ namespace SFServer.UI.Models
     {
         public Guid Id { get; set; }
 
+        [Display(Name = "Server Title")]
+        public string ServerTitle { get; set; } = string.Empty;
+
         [Display(Name = "Copyright")]
         public string ServerCopyright { get; set; } = string.Empty;
 

--- a/SFServer.UI/Views/ServerSettings/Index.cshtml
+++ b/SFServer.UI/Views/ServerSettings/Index.cshtml
@@ -18,6 +18,10 @@
     @Html.AntiForgeryToken()
     <input type="hidden" asp-for="Id" />
     <div class="mb-3">
+        <label asp-for="ServerTitle" class="form-label"></label>
+        <input asp-for="ServerTitle" class="form-control" />
+    </div>
+    <div class="mb-3">
         <label asp-for="ServerCopyright" class="form-label"></label>
         <input asp-for="ServerCopyright" class="form-control" />
     </div>

--- a/SFServer.UI/Views/Shared/_Layout.cshtml
+++ b/SFServer.UI/Views/Shared/_Layout.cshtml
@@ -3,6 +3,10 @@
 @using SFServer.Shared.Server.UserProfile
 @inject IConfiguration Configuration
 @using SFServer.UI
+@inject ServerSettingsService SettingsService
+@{
+    var settings = await SettingsService.GetSettingsAsync();
+}
 
 <!DOCTYPE html>
 <html lang="en" data-bs-theme="light">
@@ -30,7 +34,7 @@
     <nav class="navbar navbar-expand-sm navbar-toggleable-sm navbar-light bg-light border-bottom box-shadow mb-3">
         <div class="container-fluid">
             <a class="navbar-brand" asp-area="" asp-controller="Home" asp-action="Index">
-                @Configuration["SERVER_TITLE"]
+                @(settings?.ServerTitle ?? Configuration["SERVER_TITLE"])
             </a>
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target=".navbar-collapse"
                     aria-controls="navbarSupportedContent"
@@ -122,10 +126,6 @@
     </main>
 </div>
 
-@inject ServerSettingsService SettingsService
-@{
-    var settings = await SettingsService.GetSettingsAsync();
-}
 <footer class="footer border-top text-body-secondary bg-body-tertiary">
     <div class="container d-flex justify-content-between align-items-center flex-wrap py-3">
         <span>@settings?.ServerCopyright</span>


### PR DESCRIPTION
## Summary
- allow editing server title in settings
- show server title in layout from settings service
- seed ServerTitle from env
- add migration for ServerTitle

## Testing
- `dotnet build SFServer.Shared/SFServer.Shared.csproj -c Release`
- `dotnet build SFServer.API/SFServer.API.csproj -c Release`
- `dotnet build SFServer.UI/SFServer.UI.csproj -c Release`

------
https://chatgpt.com/codex/tasks/task_e_686afe337f948323900f53ff88433614