### PR TITLE
Use header-based userId

### DIFF
--- a/SFServer.API/Controllers/AuthController.cs
+++ b/SFServer.API/Controllers/AuthController.cs
@@ -483,9 +483,13 @@ namespace SFServer.API.Controllers
             }
 
             // Получаем текущего пользователя
-            var userIdClaim = User.FindFirst("UserId")?.Value;
-            if (!Guid.TryParse(userIdClaim, out Guid userId))
-                return Unauthorized("Invalid or missing UserId claim.");
+            var userIdValue = Request.Headers[Headers.UID].FirstOrDefault();
+            if (string.IsNullOrEmpty(userIdValue))
+            {
+                userIdValue = User.FindFirst("UserId")?.Value;
+            }
+            if (!Guid.TryParse(userIdValue, out Guid userId))
+                return Unauthorized("Invalid or missing UserId.");
 
             var user = await _db.UserProfiles.FindAsync(userId);
             if (user == null)

--- a/SFServer.API/Controllers/PurchasesController.cs
+++ b/SFServer.API/Controllers/PurchasesController.cs
@@ -58,8 +58,12 @@ public class PurchasesController : ControllerBase
 
             if (result.PurchaseState == 0)
             {
-                var userIdClaim = User.FindFirst("UserId")?.Value;
-                if (Guid.TryParse(userIdClaim, out var userId))
+                var userIdValue = Request.Headers[Headers.UID].FirstOrDefault();
+                if (string.IsNullOrEmpty(userIdValue))
+                {
+                    userIdValue = User.FindFirst("UserId")?.Value;
+                }
+                if (Guid.TryParse(userIdValue, out var userId))
                 {
                     var item = await _db.InventoryItems.FirstOrDefaultAsync(i => i.ProductId == request.ProductId);
                     if (item != null)

--- a/SFServer.API/Controllers/UserProfilesController.cs
+++ b/SFServer.API/Controllers/UserProfilesController.cs
@@ -138,7 +138,12 @@ namespace SFServer.API.Controllers
             existing.DebugMode = updated.DebugMode;
 
             // Determine if current user is trying to change someone else's password
-            bool isSelf = User.FindFirst("UserId")?.Value == existing.Id.ToString();
+            var currentUserId = Request.Headers[Headers.UID].FirstOrDefault();
+            if (string.IsNullOrEmpty(currentUserId))
+            {
+                currentUserId = User.FindFirst("UserId")?.Value;
+            }
+            bool isSelf = currentUserId == existing.Id.ToString();
             bool isAdmin = User.IsInRole("Admin");
 
             if (!string.IsNullOrEmpty(updated.PasswordHash))

--- a/SFServer.API/Utils/AuditLogMiddleware.cs
+++ b/SFServer.API/Utils/AuditLogMiddleware.cs
@@ -20,10 +20,14 @@ namespace SFServer.API.Utils
         {
             await _next(context);
 
-            var userIdString = context.User?.FindFirstValue("UserId");
-            if (string.IsNullOrEmpty(userIdString) && context.Request.Headers.TryGetValue("UserId", out var headerUserId))
+            string userIdString = null;
+            if (context.Request.Headers.TryGetValue(Headers.UID, out var headerUserId))
             {
                 userIdString = headerUserId.ToString();
+            }
+            if (string.IsNullOrEmpty(userIdString))
+            {
+                userIdString = context.User?.FindFirstValue("UserId");
             }
             
             Console.WriteLine("User Id: " + userIdString);


### PR DESCRIPTION
## Summary
- fetch UserId from request headers for purchases
- parse headers for UserId in `LinkGooglePlay`
- read UserId header when editing user profiles
- update audit log middleware to check UserId header first
- run `dotnet build`

## Testing
- `dotnet build SFServer.sln`

------
https://chatgpt.com/codex/tasks/task_e_6874467af0fc8323a6027e2d4db7f8ae