### PR TITLE
Add basic multi-project support

### DIFF
--- a/SFServer.API/Controllers/ProjectsController.cs
+++ b/SFServer.API/Controllers/ProjectsController.cs
@@ -1,0 +1,38 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using SFServer.API.Data;
+using SFServer.Shared.Server.Project;
+
+namespace SFServer.API.Controllers;
+
+[ApiController]
+[Route("[controller]")]
+[Authorize(Roles = "Admin,Developer")]
+public class ProjectsController : ControllerBase
+{
+    private readonly DatabseContext _db;
+
+    public ProjectsController(DatabseContext db)
+    {
+        _db = db;
+    }
+
+    [HttpGet]
+    [AllowAnonymous]
+    public async Task<IActionResult> GetAll()
+    {
+        var list = await _db.Projects.ToListAsync();
+        return Ok(list);
+    }
+
+    [HttpPost]
+    [Authorize(Roles = "Admin")]
+    public async Task<IActionResult> Create([FromBody] ProjectInfo project)
+    {
+        project.Id = Guid.NewGuid();
+        _db.Projects.Add(project);
+        await _db.SaveChangesAsync();
+        return CreatedAtAction(nameof(GetAll), new { id = project.Id }, project);
+    }
+}

--- a/SFServer.API/Data/DatabseContext.cs
+++ b/SFServer.API/Data/DatabseContext.cs
@@ -5,6 +5,7 @@ using SFServer.Shared.Server.Wallet;
 using SFServer.Shared.Server.Inventory;
 using SFServer.Shared.Server.Settings;
 using SFServer.Shared.Server.Audit;
+using SFServer.Shared.Server.Project;
 
 namespace SFServer.API.Data
 {
@@ -17,6 +18,8 @@ namespace SFServer.API.Data
         public DbSet<UserProfile> UserProfiles { get; set; }
         public DbSet<WalletItem> WalletItems { get; set; }
         public DbSet<Currency> Currencies { get; set; }
+
+        public DbSet<ProjectInfo> Projects { get; set; }
 
         public DbSet<UserDevice> UserDevices { get; set; }
 

--- a/SFServer.API/Headers.cs
+++ b/SFServer.API/Headers.cs
@@ -1,5 +1,6 @@
 ﻿namespace SFServer.API {
     public static class Headers {
         public const string UID = "UserId";
+        public const string PID = "ProjectId";
     }
 }

--- a/SFServer.API/Migrations/20250715222859_AddProjectSupport.Designer.cs
+++ b/SFServer.API/Migrations/20250715222859_AddProjectSupport.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SFServer.API.Data;
@@ -12,9 +13,11 @@ using SFServer.API.Data;
 namespace SFServer.API.Migrations
 {
     [DbContext(typeof(DatabseContext))]
-    partial class UserProfilesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250715222859_AddProjectSupport")]
+    partial class AddProjectSupport
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/SFServer.API/Migrations/20250715222859_AddProjectSupport.cs
+++ b/SFServer.API/Migrations/20250715222859_AddProjectSupport.cs
@@ -1,0 +1,122 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SFServer.API.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddProjectSupport : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "ProjectId",
+                table: "WalletItems",
+                type: "uuid",
+                nullable: false,
+                defaultValue: new Guid("00000000-0000-0000-0000-000000000000"));
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "ProjectId",
+                table: "UserProfiles",
+                type: "uuid",
+                nullable: false,
+                defaultValue: new Guid("00000000-0000-0000-0000-000000000000"));
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "ProjectId",
+                table: "UserDevices",
+                type: "uuid",
+                nullable: false,
+                defaultValue: new Guid("00000000-0000-0000-0000-000000000000"));
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "ProjectId",
+                table: "ServerSettings",
+                type: "uuid",
+                nullable: false,
+                defaultValue: new Guid("00000000-0000-0000-0000-000000000000"));
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "ProjectId",
+                table: "PlayerInventoryItems",
+                type: "uuid",
+                nullable: false,
+                defaultValue: new Guid("00000000-0000-0000-0000-000000000000"));
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "ProjectId",
+                table: "InventoryItems",
+                type: "uuid",
+                nullable: false,
+                defaultValue: new Guid("00000000-0000-0000-0000-000000000000"));
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "ProjectId",
+                table: "Currencies",
+                type: "uuid",
+                nullable: false,
+                defaultValue: new Guid("00000000-0000-0000-0000-000000000000"));
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "ProjectId",
+                table: "AuditLogs",
+                type: "uuid",
+                nullable: false,
+                defaultValue: new Guid("00000000-0000-0000-0000-000000000000"));
+
+            migrationBuilder.CreateTable(
+                name: "Projects",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    Name = table.Column<string>(type: "text", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Projects", x => x.Id);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Projects");
+
+            migrationBuilder.DropColumn(
+                name: "ProjectId",
+                table: "WalletItems");
+
+            migrationBuilder.DropColumn(
+                name: "ProjectId",
+                table: "UserProfiles");
+
+            migrationBuilder.DropColumn(
+                name: "ProjectId",
+                table: "UserDevices");
+
+            migrationBuilder.DropColumn(
+                name: "ProjectId",
+                table: "ServerSettings");
+
+            migrationBuilder.DropColumn(
+                name: "ProjectId",
+                table: "PlayerInventoryItems");
+
+            migrationBuilder.DropColumn(
+                name: "ProjectId",
+                table: "InventoryItems");
+
+            migrationBuilder.DropColumn(
+                name: "ProjectId",
+                table: "Currencies");
+
+            migrationBuilder.DropColumn(
+                name: "ProjectId",
+                table: "AuditLogs");
+        }
+    }
+}

--- a/SFServer.API/Program.cs
+++ b/SFServer.API/Program.cs
@@ -165,12 +165,27 @@ using (var scope = app.Services.CreateScope())
         Console.WriteLine($"ℹ️ Admin user '{adminUsername}' already exists.");
     }
 
+    // Seed projects
+    var project = context.Projects.FirstOrDefault();
+    if (project == null)
+    {
+        project = new SFServer.Shared.Server.Project.ProjectInfo
+        {
+            Id = Guid.NewGuid(),
+            Name = config["DEFAULT_PROJECT_NAME"] ?? "Default"
+        };
+        context.Projects.Add(project);
+        context.SaveChanges();
+        Console.WriteLine("✅ Default project created.");
+    }
+
     // Seed server settings from environment variables if not present
     if (!context.ServerSettings.Any())
     {
         var settings = new SFServer.Shared.Server.Settings.ServerSettings
         {
             Id = Guid.NewGuid(),
+            ProjectId = project.Id,
             ServerTitle = config["SERVER_TITLE"] ?? string.Empty,
             ServerCopyright = config["SERVER_COPYRIGHT"] ?? string.Empty,
             GoogleClientId = config["GOOGLE_CLIENT_ID"] ?? string.Empty,

--- a/SFServer.Shared/Server/Audit/AuditLogEntry.cs
+++ b/SFServer.Shared/Server/Audit/AuditLogEntry.cs
@@ -7,6 +7,7 @@ namespace SFServer.Shared.Server.Audit
     public partial class AuditLogEntry
     {
         public Guid Id { get; set; }
+        public Guid ProjectId { get; set; }
         public Guid? UserId { get; set; }
         public string Path { get; set; }
         public string Method { get; set; }

--- a/SFServer.Shared/Server/Inventory/InventoryItem.cs
+++ b/SFServer.Shared/Server/Inventory/InventoryItem.cs
@@ -8,6 +8,7 @@ namespace SFServer.Shared.Server.Inventory
     public partial class InventoryItem
     {
         public Guid Id { get; set; }
+        public Guid ProjectId { get; set; }
         public string Title { get; set; }
         public InventoryItemType Type { get; set; }
         public InventoryItemRarity Rarity { get; set; }

--- a/SFServer.Shared/Server/Inventory/PlayerInventoryItem.cs
+++ b/SFServer.Shared/Server/Inventory/PlayerInventoryItem.cs
@@ -7,6 +7,7 @@ namespace SFServer.Shared.Server.Inventory
     public partial class PlayerInventoryItem
     {
         public Guid Id { get; set; }
+        public Guid ProjectId { get; set; }
         public Guid UserId { get; set; }
         public Guid ItemId { get; set; }
         public int Amount { get; set; }

--- a/SFServer.Shared/Server/Project/ProjectInfo.cs
+++ b/SFServer.Shared/Server/Project/ProjectInfo.cs
@@ -1,0 +1,11 @@
+using System;
+using MemoryPack;
+
+namespace SFServer.Shared.Server.Project;
+
+[MemoryPackable]
+public partial class ProjectInfo
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+}

--- a/SFServer.Shared/Server/Settings/ServerSettings.cs
+++ b/SFServer.Shared/Server/Settings/ServerSettings.cs
@@ -7,6 +7,7 @@ namespace SFServer.Shared.Server.Settings
     public partial class ServerSettings
     {
         public Guid Id { get; set; }
+        public Guid ProjectId { get; set; }
         public string ServerTitle { get; set; } = string.Empty;
         public string ServerCopyright { get; set; } = string.Empty;
         public string GoogleClientId { get; set; } = string.Empty;

--- a/SFServer.Shared/Server/UserProfile/UserDevice.cs
+++ b/SFServer.Shared/Server/UserProfile/UserDevice.cs
@@ -8,6 +8,7 @@ namespace SFServer.Shared.Server.UserProfile
     public partial class UserDevice
     {
         public Guid Id { get; set; }
+        public Guid ProjectId { get; set; }
         public Guid UserId { get; set; }
         public string DeviceId { get; set; }
         public string DeviceModel { get; set; }

--- a/SFServer.Shared/Server/UserProfile/UserProfile.cs
+++ b/SFServer.Shared/Server/UserProfile/UserProfile.cs
@@ -10,6 +10,7 @@ namespace SFServer.Shared.Server.UserProfile
     {
         public Guid Id { get; set; }
         public int Index { get; private set; }
+        public Guid ProjectId { get; set; }
         public string Username { get; set; }
         public string FullName { get; set; }
         public int? Age { get; set; }

--- a/SFServer.Shared/Server/Wallet/Currency.cs
+++ b/SFServer.Shared/Server/Wallet/Currency.cs
@@ -7,6 +7,7 @@ namespace SFServer.Shared.Server.Wallet
     public partial class Currency
     {
         public Guid Id { get; set; }
+        public Guid ProjectId { get; set; }
 
         public string Title { get; set; }
         

--- a/SFServer.Shared/Server/Wallet/WalletItem.cs
+++ b/SFServer.Shared/Server/Wallet/WalletItem.cs
@@ -7,6 +7,7 @@ namespace SFServer.Shared.Server.Wallet
     public partial class WalletItem
     {
         public Guid Id { get; set; }
+        public Guid ProjectId { get; set; }
 
         // Foreign key to user
         public Guid UserId { get; set; }

--- a/SFServer.UI/Controllers/ProjectsController.cs
+++ b/SFServer.UI/Controllers/ProjectsController.cs
@@ -1,0 +1,43 @@
+using System.Net.Http;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
+using SFServer.Shared.Server.Project;
+
+namespace SFServer.UI.Controllers;
+
+[Authorize]
+public class ProjectsController : Controller
+{
+    private readonly IConfiguration _config;
+    private readonly ProjectContext _context;
+
+    public ProjectsController(IConfiguration config, ProjectContext context)
+    {
+        _config = config;
+        _context = context;
+    }
+
+    private HttpClient GetClient() => User.CreateApiClient(_config, _context.CurrentProjectId);
+
+    public async Task<IActionResult> Index()
+    {
+        using var client = User.CreateApiClient(_config);
+        var projects = await client.GetFromMessagePackAsync<List<ProjectInfo>>("Projects");
+        return View(projects);
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> Select(Guid id)
+    {
+        using var client = User.CreateApiClient(_config);
+        var list = await client.GetFromMessagePackAsync<List<ProjectInfo>>("Projects");
+        var proj = list.FirstOrDefault(p => p.Id == id);
+        if (proj != null)
+        {
+            _context.CurrentProjectId = proj.Id;
+            _context.CurrentProjectName = proj.Name;
+        }
+        return RedirectToAction("Index", "Home");
+    }
+}

--- a/SFServer.UI/Controllers/ServerSettingsController.cs
+++ b/SFServer.UI/Controllers/ServerSettingsController.cs
@@ -16,15 +16,17 @@ namespace SFServer.UI.Controllers
     {
         private readonly IConfiguration _configuration;
         private readonly ServerSettingsService _service;
-        public ServerSettingsController(IConfiguration configuration, ServerSettingsService service)
+        private readonly ProjectContext _project;
+        public ServerSettingsController(IConfiguration configuration, ServerSettingsService service, ProjectContext project)
         {
             _configuration = configuration;
             _service = service;
+            _project = project;
         }
 
         private HttpClient GetAuthenticatedHttpClient()
         {
-            return User.CreateApiClient(_configuration);
+            return User.CreateApiClient(_configuration, _project.CurrentProjectId);
         }
 
         public async Task<IActionResult> Index()

--- a/SFServer.UI/HttpClientMessagePackExtensions.cs
+++ b/SFServer.UI/HttpClientMessagePackExtensions.cs
@@ -20,7 +20,7 @@ namespace SFServer.UI
         // Configure MessagePack options to use ContractlessStandardResolver.
         private static readonly MemoryPackSerializerOptions DefaultOptions = MemoryPackSerializerOptions.Default;
 
-        public static HttpClient CreateApiClient(this ClaimsPrincipal user, IConfiguration config)
+        public static HttpClient CreateApiClient(this ClaimsPrincipal user, IConfiguration config, Guid projectId = default)
         {
             var client = new HttpClient { BaseAddress = new Uri(config["API_BASE_URL"]) };
 
@@ -37,6 +37,10 @@ namespace SFServer.UI
                 Console.WriteLine("UserId" + userId);
             }
 
+            if (projectId != Guid.Empty)
+            {
+                client.DefaultRequestHeaders.Add("ProjectId", projectId.ToString());
+            }
             return client;
         }
 

--- a/SFServer.UI/Program.cs
+++ b/SFServer.UI/Program.cs
@@ -50,6 +50,7 @@ builder.Services.AddHttpClient("api", c =>
     c.BaseAddress = new Uri(builder.Configuration["API_BASE_URL"]);
 });
 builder.Services.AddSingleton<ServerSettingsService>();
+builder.Services.AddSingleton<ProjectContext>();
 
 var app = builder.Build();
 

--- a/SFServer.UI/ProjectContext.cs
+++ b/SFServer.UI/ProjectContext.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace SFServer.UI;
+
+public class ProjectContext
+{
+    public Guid CurrentProjectId { get; set; }
+    public string CurrentProjectName { get; set; } = string.Empty;
+}

--- a/SFServer.UI/Views/Projects/Index.cshtml
+++ b/SFServer.UI/Views/Projects/Index.cshtml
@@ -1,0 +1,11 @@
+@model List<SFServer.Shared.Server.Project.ProjectInfo>
+@using Microsoft.AspNetCore.Mvc.Rendering
+@{
+    ViewData["Title"] = "Projects";
+}
+<h1>Projects</h1>
+<form asp-action="Select" method="post">
+    <select name="id" class="form-select" asp-items="@(new SelectList(Model, "Id", "Name", null))"></select>
+    <button type="submit" class="btn btn-primary mt-2">Select</button>
+</form>
+

--- a/SFServer.UI/Views/Shared/_Layout.cshtml
+++ b/SFServer.UI/Views/Shared/_Layout.cshtml
@@ -4,6 +4,7 @@
 @inject IConfiguration Configuration
 @using SFServer.UI
 @inject ServerSettingsService SettingsService
+@inject ProjectContext ProjectContext
 @{
     var settings = await SettingsService.GetSettingsAsync();
 }
@@ -61,6 +62,11 @@
                             </a>
                         </li>
                         <li class="nav-item">
+                            <a class="nav-link text-dark" asp-controller="Projects" asp-action="Index">
+                                <i class="bi bi-collection"></i> Projects
+                            </a>
+                        </li>
+                        <li class="nav-item">
                             <a class="nav-link text-dark" asp-page="/Inventory/Index">
                                 <i class="bi bi-box"></i> Inventory
                             </a>
@@ -75,6 +81,7 @@
                 @if (User.Identity?.IsAuthenticated == true)
                 {
                     <div class="d-flex align-items-center">
+                        <span class="me-3 text-info">@ProjectContext.CurrentProjectName</span>
                         <span id="server-time" class="me-3 text-primary fw-bold">--:--:--</span>
                         @{
                             var userId = User.FindFirst("UserId")?.Value;


### PR DESCRIPTION
## Summary
- introduce `ProjectInfo` entity and include new `ProjectContext` service
- support multiple projects in ServerSettings, users, inventory and wallet models
- add `ProjectsController` for API and UI
- extend HTTP client helper with ProjectId header
- allow selecting active project via UI
- add EF migration for the new ProjectId columns and Projects table

## Testing
- `dotnet build SFServer.sln`

------
https://chatgpt.com/codex/tasks/task_e_6876d41b1f0c832387122457fb6456f4