### PR TITLE
Add administrator management

### DIFF
--- a/SFServer.API/Controllers/AdministratorsController.cs
+++ b/SFServer.API/Controllers/AdministratorsController.cs
@@ -52,9 +52,9 @@ public class AdministratorsController : ControllerBase
     }
 
     [HttpDelete("{id:guid}")]
-    public async Task<IActionResult> Delete(Guid id)
-    {
-        if (id == Guid.Empty) return BadRequest();
+    public async Task<IActionResult> Delete(Guid id) {
+        var count = await _db.Administrators.CountAsync();
+        if (count  == 1) return BadRequest();
         var admin = await _db.Administrators.FindAsync(id);
         if (admin == null) return NotFound();
         _db.Administrators.Remove(admin);

--- a/SFServer.API/Controllers/AdministratorsController.cs
+++ b/SFServer.API/Controllers/AdministratorsController.cs
@@ -40,7 +40,7 @@ public class AdministratorsController : ControllerBase
 
         var admin = new Administrator
         {
-            Id = await _db.Administrators.AnyAsync() ? Guid.CreateVersion7() : Guid.Empty,
+            Id = Guid.CreateVersion7(),
             Username = request.Username,
             Email = request.Email,
             CreatedAt = DateTime.UtcNow
@@ -54,9 +54,9 @@ public class AdministratorsController : ControllerBase
     [HttpDelete("{id:guid}")]
     public async Task<IActionResult> Delete(Guid id)
     {
+        if (id == Guid.Empty) return BadRequest();
         var admin = await _db.Administrators.FindAsync(id);
         if (admin == null) return NotFound();
-        if (admin.Id == Guid.Empty) return BadRequest("Cannot delete root administrator.");
         _db.Administrators.Remove(admin);
         await _db.SaveChangesAsync();
         return NoContent();

--- a/SFServer.API/Controllers/AdministratorsController.cs
+++ b/SFServer.API/Controllers/AdministratorsController.cs
@@ -1,0 +1,64 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using SFServer.API.Data;
+using SFServer.Shared.Server.Admin;
+using SFServer.Shared.Server.UserProfile;
+
+namespace SFServer.API.Controllers;
+
+[ApiController]
+[Route("[controller]")]
+[Authorize(Roles = "Admin")]
+public class AdministratorsController : ControllerBase
+{
+    private readonly DatabseContext _db;
+    private readonly IPasswordHasher<Administrator> _hasher;
+
+    public AdministratorsController(DatabseContext db, IPasswordHasher<Administrator> hasher)
+    {
+        _db = db;
+        _hasher = hasher;
+    }
+
+    [HttpGet]
+    public async Task<IActionResult> GetAll()
+    {
+        var admins = await _db.Administrators.ToListAsync();
+        return Ok(admins);
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> Create([FromBody] CreateAdminRequest request)
+    {
+        if (!ModelState.IsValid) return BadRequest(ModelState);
+        if (await _db.Administrators.AnyAsync(a => a.Username.ToLower() == request.Username.ToLower()))
+            return BadRequest("Username already exists.");
+        if (!string.IsNullOrEmpty(request.Email) && await _db.Administrators.AnyAsync(a => a.Email.ToLower() == request.Email.ToLower()))
+            return BadRequest("Email already exists.");
+
+        var admin = new Administrator
+        {
+            Id = Guid.CreateVersion7(),
+            Username = request.Username,
+            Email = request.Email,
+            CreatedAt = DateTime.UtcNow
+        };
+        admin.PasswordHash = _hasher.HashPassword(admin, request.Password);
+        _db.Administrators.Add(admin);
+        await _db.SaveChangesAsync();
+        return Ok(admin);
+    }
+
+    [HttpDelete("{id:guid}")]
+    public async Task<IActionResult> Delete(Guid id)
+    {
+        var admin = await _db.Administrators.FindAsync(id);
+        if (admin == null) return NotFound();
+        if (admin.Id == Guid.Empty) return BadRequest("Cannot delete root administrator.");
+        _db.Administrators.Remove(admin);
+        await _db.SaveChangesAsync();
+        return NoContent();
+    }
+}

--- a/SFServer.API/Controllers/AdministratorsController.cs
+++ b/SFServer.API/Controllers/AdministratorsController.cs
@@ -40,7 +40,7 @@ public class AdministratorsController : ControllerBase
 
         var admin = new Administrator
         {
-            Id = Guid.CreateVersion7(),
+            Id = await _db.Administrators.AnyAsync() ? Guid.CreateVersion7() : Guid.Empty,
             Username = request.Username,
             Email = request.Email,
             CreatedAt = DateTime.UtcNow

--- a/SFServer.API/Controllers/AuditLogController.cs
+++ b/SFServer.API/Controllers/AuditLogController.cs
@@ -11,7 +11,7 @@ using System.Threading.Tasks;
 namespace SFServer.API.Controllers
 {
     [ApiController]
-    [Route("[controller]")]
+    [Route("{projectId:guid}/[controller]")]
     [Authorize(Roles = "Admin")]
     public class AuditLogController : ControllerBase
     {
@@ -22,10 +22,8 @@ namespace SFServer.API.Controllers
         }
 
         [HttpGet]
-        public async Task<ActionResult<List<AuditLogEntry>>> Get([FromQuery] int count = 100)
+        public async Task<ActionResult<List<AuditLogEntry>>> Get(Guid projectId, [FromQuery] int count = 100)
         {
-            if (!Guid.TryParse(Request.Headers[Headers.PID], out var projectId))
-                return BadRequest("ProjectId header required");
             var logs = await _db.AuditLogs
                 .Where(l => l.ProjectId == projectId)
                 .OrderByDescending(l => l.Timestamp)
@@ -35,10 +33,8 @@ namespace SFServer.API.Controllers
         }
 
         [HttpDelete]
-        public async Task<IActionResult> Clear()
+        public async Task<IActionResult> Clear(Guid projectId)
         {
-            if (!Guid.TryParse(Request.Headers[Headers.PID], out var projectId))
-                return BadRequest("ProjectId header required");
             var toRemove = _db.AuditLogs.Where(l => l.ProjectId == projectId);
             _db.AuditLogs.RemoveRange(toRemove);
             await _db.SaveChangesAsync();
@@ -46,10 +42,8 @@ namespace SFServer.API.Controllers
         }
 
         [HttpGet("export")]
-        public async Task<IActionResult> Export()
+        public async Task<IActionResult> Export(Guid projectId)
         {
-            if (!Guid.TryParse(Request.Headers[Headers.PID], out var projectId))
-                return BadRequest("ProjectId header required");
             var logs = await _db.AuditLogs
                 .Where(l => l.ProjectId == projectId)
                 .OrderByDescending(l => l.Timestamp)

--- a/SFServer.API/Controllers/AuditLogController.cs
+++ b/SFServer.API/Controllers/AuditLogController.cs
@@ -24,7 +24,10 @@ namespace SFServer.API.Controllers
         [HttpGet]
         public async Task<ActionResult<List<AuditLogEntry>>> Get([FromQuery] int count = 100)
         {
+            if (!Guid.TryParse(Request.Headers[Headers.PID], out var projectId))
+                return BadRequest("ProjectId header required");
             var logs = await _db.AuditLogs
+                .Where(l => l.ProjectId == projectId)
                 .OrderByDescending(l => l.Timestamp)
                 .Take(count)
                 .ToListAsync();
@@ -34,7 +37,10 @@ namespace SFServer.API.Controllers
         [HttpDelete]
         public async Task<IActionResult> Clear()
         {
-            _db.AuditLogs.RemoveRange(_db.AuditLogs);
+            if (!Guid.TryParse(Request.Headers[Headers.PID], out var projectId))
+                return BadRequest("ProjectId header required");
+            var toRemove = _db.AuditLogs.Where(l => l.ProjectId == projectId);
+            _db.AuditLogs.RemoveRange(toRemove);
             await _db.SaveChangesAsync();
             return NoContent();
         }
@@ -42,7 +48,10 @@ namespace SFServer.API.Controllers
         [HttpGet("export")]
         public async Task<IActionResult> Export()
         {
+            if (!Guid.TryParse(Request.Headers[Headers.PID], out var projectId))
+                return BadRequest("ProjectId header required");
             var logs = await _db.AuditLogs
+                .Where(l => l.ProjectId == projectId)
                 .OrderByDescending(l => l.Timestamp)
                 .ToListAsync();
 

--- a/SFServer.API/Controllers/CurrencyController.cs
+++ b/SFServer.API/Controllers/CurrencyController.cs
@@ -7,7 +7,7 @@ using SFServer.Shared.Server.Wallet;
 namespace SFServer.API.Controllers
 {
     [ApiController]
-    [Route("[controller]")]
+    [Route("{projectId:guid}/[controller]")]
     [Authorize(Roles = "Admin,Developer")]
     public class CurrencyController : ControllerBase
     {
@@ -19,10 +19,8 @@ namespace SFServer.API.Controllers
         
         // GET /Currency
         [HttpGet]
-        public async Task<IActionResult> GetAll()
+        public async Task<IActionResult> GetAll(Guid projectId)
         {
-            if (!Guid.TryParse(Request.Headers[Headers.PID], out var projectId))
-                return BadRequest("ProjectId header required");
             var currencies = await _context.Currencies
                 .Where(c => c.ProjectId == projectId)
                 .ToListAsync();
@@ -30,10 +28,8 @@ namespace SFServer.API.Controllers
         }
         
         [HttpGet("{id}")]
-        public async Task<IActionResult> GetCurrencyById(Guid id)
+        public async Task<IActionResult> GetCurrencyById(Guid projectId, Guid id)
         {
-            if (!Guid.TryParse(Request.Headers[Headers.PID], out var projectId))
-                return BadRequest("ProjectId header required");
             var currency = await _context.Currencies.FirstOrDefaultAsync(c => c.Id == id && c.ProjectId == projectId);
             if (currency == null)
             {
@@ -44,13 +40,10 @@ namespace SFServer.API.Controllers
         
         // POST /Currency/create
         [HttpPost("create")]
-        public async Task<IActionResult> Create([FromBody] Currency currency)
+        public async Task<IActionResult> Create(Guid projectId, [FromBody] Currency currency)
         {
             if (!ModelState.IsValid)
                 return BadRequest(ModelState);
-
-            if (!Guid.TryParse(Request.Headers[Headers.PID], out var projectId))
-                return BadRequest("ProjectId header required");
 
             currency.ProjectId = projectId;
             _context.Currencies.Add(currency);
@@ -59,13 +52,11 @@ namespace SFServer.API.Controllers
         }
         
         [HttpPut("{id}")]
-        public async Task<IActionResult> UpdateCurrency(Guid id, [FromBody] Currency updatedCurrency)
+        public async Task<IActionResult> UpdateCurrency(Guid projectId, Guid id, [FromBody] Currency updatedCurrency)
         {
             if (id != updatedCurrency.Id)
                 return BadRequest("ID mismatch.");
 
-            if (!Guid.TryParse(Request.Headers[Headers.PID], out var projectId))
-                return BadRequest("ProjectId header required");
 
             var existingCurrency = await _context.Currencies.FirstOrDefaultAsync(c => c.Id == id && c.ProjectId == projectId);
             if (existingCurrency == null)
@@ -86,10 +77,8 @@ namespace SFServer.API.Controllers
         
         // DELETE /Currency/{id}
         [HttpDelete("{id}")]
-        public async Task<IActionResult> DeleteCurrency(Guid id)
+        public async Task<IActionResult> DeleteCurrency(Guid projectId, Guid id)
         {
-            if (!Guid.TryParse(Request.Headers[Headers.PID], out var projectId))
-                return BadRequest("ProjectId header required");
             var currency = await _context.Currencies.FirstOrDefaultAsync(c => c.Id == id && c.ProjectId == projectId);
             if (currency == null)
             {

--- a/SFServer.API/Controllers/GlobalSettingsController.cs
+++ b/SFServer.API/Controllers/GlobalSettingsController.cs
@@ -1,0 +1,57 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Newtonsoft.Json;
+using SFServer.API.Data;
+using SFServer.Shared.Server.Settings;
+
+namespace SFServer.API.Controllers;
+
+[ApiController]
+[Route("[controller]")]
+[Authorize(Roles = "Admin")]
+public class GlobalSettingsController : ControllerBase
+{
+    private readonly DatabseContext _db;
+
+    public GlobalSettingsController(DatabseContext db)
+    {
+        _db = db;
+    }
+
+    [HttpGet]
+    [AllowAnonymous]
+    public async Task<IActionResult> GetSettings()
+    {
+        var settings = await _db.GlobalSettings.FirstOrDefaultAsync();
+        if (settings == null)
+            return NotFound();
+        return Ok(settings);
+    }
+
+    [HttpPut]
+    public async Task<IActionResult> UpdateSettings([FromBody] GlobalSettings updated)
+    {
+        var existing = await _db.GlobalSettings.FirstOrDefaultAsync();
+        if (existing == null)
+        {
+            updated.Id = Guid.NewGuid();
+            _db.GlobalSettings.Add(updated);
+        }
+        else
+        {
+            existing.ServerTitle = updated.ServerTitle;
+            existing.ServerCopyright = updated.ServerCopyright;
+            existing.GoogleClientId = updated.GoogleClientId;
+            existing.GoogleClientSecret = updated.GoogleClientSecret;
+            existing.ClickHouseConnection = updated.ClickHouseConnection;
+            if (!string.IsNullOrEmpty(updated.GoogleServiceAccountJson))
+            {
+                dynamic parsedJson = JsonConvert.DeserializeObject(updated.GoogleServiceAccountJson);
+                existing.GoogleServiceAccountJson = parsedJson == null ? updated.GoogleServiceAccountJson : (string)JsonConvert.SerializeObject(parsedJson, Formatting.Indented);
+            }
+        }
+        await _db.SaveChangesAsync();
+        return NoContent();
+    }
+}

--- a/SFServer.API/Controllers/GlobalSettingsController.cs
+++ b/SFServer.API/Controllers/GlobalSettingsController.cs
@@ -34,7 +34,7 @@ public class GlobalSettingsController : ControllerBase
         var existing = await _db.GlobalSettings.FirstOrDefaultAsync();
         if (existing == null)
         {
-            updated.Id = Guid.NewGuid();
+            updated.Id = Guid.CreateVersion7();
             _db.GlobalSettings.Add(updated);
         }
         else

--- a/SFServer.API/Controllers/GlobalSettingsController.cs
+++ b/SFServer.API/Controllers/GlobalSettingsController.cs
@@ -1,7 +1,6 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
-using Newtonsoft.Json;
 using SFServer.API.Data;
 using SFServer.Shared.Server.Settings;
 
@@ -42,14 +41,6 @@ public class GlobalSettingsController : ControllerBase
         {
             existing.ServerTitle = updated.ServerTitle;
             existing.ServerCopyright = updated.ServerCopyright;
-            existing.GoogleClientId = updated.GoogleClientId;
-            existing.GoogleClientSecret = updated.GoogleClientSecret;
-            existing.ClickHouseConnection = updated.ClickHouseConnection;
-            if (!string.IsNullOrEmpty(updated.GoogleServiceAccountJson))
-            {
-                dynamic parsedJson = JsonConvert.DeserializeObject(updated.GoogleServiceAccountJson);
-                existing.GoogleServiceAccountJson = parsedJson == null ? updated.GoogleServiceAccountJson : (string)JsonConvert.SerializeObject(parsedJson, Formatting.Indented);
-            }
         }
         await _db.SaveChangesAsync();
         return NoContent();

--- a/SFServer.API/Controllers/InventoryController.cs
+++ b/SFServer.API/Controllers/InventoryController.cs
@@ -6,7 +6,7 @@ using SFServer.Shared.Server.Inventory;
 namespace SFServer.API.Controllers
 {
     [ApiController]
-    [Route("[controller]")]
+    [Route("{projectId:guid}/[controller]")]
     [Authorize(Roles = "Admin,Developer")]
     public class InventoryController : ControllerBase
     {
@@ -18,29 +18,23 @@ namespace SFServer.API.Controllers
         }
 
         [HttpGet]
-        public async Task<IActionResult> GetItems()
+        public async Task<IActionResult> GetItems(Guid projectId)
         {
-            if (!Guid.TryParse(Request.Headers[Headers.PID], out var projectId))
-                return BadRequest("ProjectId header required");
             var items = await _service.GetItemsAsync(projectId);
             return Ok(items);
         }
 
         [HttpGet("{id:guid}")]
-        public async Task<IActionResult> GetItem(Guid id)
+        public async Task<IActionResult> GetItem(Guid projectId, Guid id)
         {
-            if (!Guid.TryParse(Request.Headers[Headers.PID], out var projectId))
-                return BadRequest("ProjectId header required");
             var item = await _service.GetItemAsync(projectId, id);
             if (item == null) return NotFound();
             return Ok(item);
         }
 
         [HttpPost]
-        public async Task<IActionResult> CreateItem([FromBody] InventoryItem item)
+        public async Task<IActionResult> CreateItem(Guid projectId, [FromBody] InventoryItem item)
         {
-            if (!Guid.TryParse(Request.Headers[Headers.PID], out var projectId))
-                return BadRequest("ProjectId header required");
             var created = await _service.CreateItemAsync(projectId, item);
             if (created == null)
             {
@@ -51,11 +45,9 @@ namespace SFServer.API.Controllers
         }
 
         [HttpPut("{id:guid}")]
-        public async Task<IActionResult> UpdateItem(Guid id, [FromBody] InventoryItem item)
+        public async Task<IActionResult> UpdateItem(Guid projectId, Guid id, [FromBody] InventoryItem item)
         {
             if (id != item.Id) return BadRequest();
-            if (!Guid.TryParse(Request.Headers[Headers.PID], out var projectId))
-                return BadRequest("ProjectId header required");
             var updated = await _service.UpdateItemAsync(projectId, item);
             if (!updated)
                 return Conflict("Item with same title or product id already exists.");
@@ -63,28 +55,22 @@ namespace SFServer.API.Controllers
         }
 
         [HttpDelete("{id:guid}")]
-        public async Task<IActionResult> DeleteItem(Guid id)
+        public async Task<IActionResult> DeleteItem(Guid projectId, Guid id)
         {
-            if (!Guid.TryParse(Request.Headers[Headers.PID], out var projectId))
-                return BadRequest("ProjectId header required");
             await _service.DeleteItemAsync(projectId, id);
             return NoContent();
         }
 
         [HttpGet("/player/{playerId}/inventory")]
-        public async Task<IActionResult> GetPlayerInventory(Guid playerId)
+        public async Task<IActionResult> GetPlayerInventory(Guid projectId, Guid playerId)
         {
-            if (!Guid.TryParse(Request.Headers[Headers.PID], out var projectId))
-                return BadRequest("ProjectId header required");
             var inv = await _service.GetPlayerInventoryAsync(projectId, playerId);
             return Ok(inv);
         }
 
         [HttpPut("/player/{playerId}/inventory")]
-        public async Task<IActionResult> UpdatePlayerInventory(Guid playerId, [FromBody] List<PlayerInventoryItem> items)
+        public async Task<IActionResult> UpdatePlayerInventory(Guid projectId, Guid playerId, [FromBody] List<PlayerInventoryItem> items)
         {
-            if (!Guid.TryParse(Request.Headers[Headers.PID], out var projectId))
-                return BadRequest("ProjectId header required");
             await _service.UpdatePlayerInventoryAsync(projectId, playerId, items);
             return NoContent();
         }

--- a/SFServer.API/Controllers/InventoryController.cs
+++ b/SFServer.API/Controllers/InventoryController.cs
@@ -61,14 +61,14 @@ namespace SFServer.API.Controllers
             return NoContent();
         }
 
-        [HttpGet("/player/{playerId}/inventory")]
+        [HttpGet("player/{playerId}/inventory")]
         public async Task<IActionResult> GetPlayerInventory(Guid projectId, Guid playerId)
         {
             var inv = await _service.GetPlayerInventoryAsync(projectId, playerId);
             return Ok(inv);
         }
 
-        [HttpPut("/player/{playerId}/inventory")]
+        [HttpPut("player/{playerId}/inventory")]
         public async Task<IActionResult> UpdatePlayerInventory(Guid projectId, Guid playerId, [FromBody] List<PlayerInventoryItem> items)
         {
             await _service.UpdatePlayerInventoryAsync(projectId, playerId, items);

--- a/SFServer.API/Controllers/InventoryController.cs
+++ b/SFServer.API/Controllers/InventoryController.cs
@@ -20,14 +20,18 @@ namespace SFServer.API.Controllers
         [HttpGet]
         public async Task<IActionResult> GetItems()
         {
-            var items = await _service.GetItemsAsync();
+            if (!Guid.TryParse(Request.Headers[Headers.PID], out var projectId))
+                return BadRequest("ProjectId header required");
+            var items = await _service.GetItemsAsync(projectId);
             return Ok(items);
         }
 
         [HttpGet("{id:guid}")]
         public async Task<IActionResult> GetItem(Guid id)
         {
-            var item = await _service.GetItemAsync(id);
+            if (!Guid.TryParse(Request.Headers[Headers.PID], out var projectId))
+                return BadRequest("ProjectId header required");
+            var item = await _service.GetItemAsync(projectId, id);
             if (item == null) return NotFound();
             return Ok(item);
         }
@@ -35,7 +39,9 @@ namespace SFServer.API.Controllers
         [HttpPost]
         public async Task<IActionResult> CreateItem([FromBody] InventoryItem item)
         {
-            var created = await _service.CreateItemAsync(item);
+            if (!Guid.TryParse(Request.Headers[Headers.PID], out var projectId))
+                return BadRequest("ProjectId header required");
+            var created = await _service.CreateItemAsync(projectId, item);
             if (created == null)
             {
                 return Conflict("Item with same title or product id already exists.");
@@ -48,7 +54,9 @@ namespace SFServer.API.Controllers
         public async Task<IActionResult> UpdateItem(Guid id, [FromBody] InventoryItem item)
         {
             if (id != item.Id) return BadRequest();
-            var updated = await _service.UpdateItemAsync(item);
+            if (!Guid.TryParse(Request.Headers[Headers.PID], out var projectId))
+                return BadRequest("ProjectId header required");
+            var updated = await _service.UpdateItemAsync(projectId, item);
             if (!updated)
                 return Conflict("Item with same title or product id already exists.");
             return NoContent();
@@ -57,21 +65,27 @@ namespace SFServer.API.Controllers
         [HttpDelete("{id:guid}")]
         public async Task<IActionResult> DeleteItem(Guid id)
         {
-            await _service.DeleteItemAsync(id);
+            if (!Guid.TryParse(Request.Headers[Headers.PID], out var projectId))
+                return BadRequest("ProjectId header required");
+            await _service.DeleteItemAsync(projectId, id);
             return NoContent();
         }
 
         [HttpGet("/player/{playerId}/inventory")]
         public async Task<IActionResult> GetPlayerInventory(Guid playerId)
         {
-            var inv = await _service.GetPlayerInventoryAsync(playerId);
+            if (!Guid.TryParse(Request.Headers[Headers.PID], out var projectId))
+                return BadRequest("ProjectId header required");
+            var inv = await _service.GetPlayerInventoryAsync(projectId, playerId);
             return Ok(inv);
         }
 
         [HttpPut("/player/{playerId}/inventory")]
         public async Task<IActionResult> UpdatePlayerInventory(Guid playerId, [FromBody] List<PlayerInventoryItem> items)
         {
-            await _service.UpdatePlayerInventoryAsync(playerId, items);
+            if (!Guid.TryParse(Request.Headers[Headers.PID], out var projectId))
+                return BadRequest("ProjectId header required");
+            await _service.UpdatePlayerInventoryAsync(projectId, playerId, items);
             return NoContent();
         }
     }

--- a/SFServer.API/Controllers/ProjectSettingsController.cs
+++ b/SFServer.API/Controllers/ProjectSettingsController.cs
@@ -10,30 +10,30 @@ namespace SFServer.API.Controllers {
     [ApiController]
     [Route("{projectId:guid}/[controller]")]
     [Authorize(Roles = "Admin")]
-    public class ServerSettingsController : ControllerBase {
+    public class ProjectSettingsController : ControllerBase {
         private readonly DatabseContext _db;
 
-        public ServerSettingsController(DatabseContext db) {
+        public ProjectSettingsController(DatabseContext db) {
             _db = db;
         }
 
         [HttpGet]
         [AllowAnonymous]
         public async Task<IActionResult> GetSettings(Guid projectId) {
-            var settings = await _db.ServerSettings.FirstOrDefaultAsync(s => s.ProjectId == projectId);
+            var settings = await _db.ProjectSettings.FirstOrDefaultAsync(s => s.ProjectId == projectId);
             if (settings == null)
                 return NotFound();
             return Ok(settings);
         }
 
         [HttpPut]
-        public async Task<IActionResult> UpdateSettings(Guid projectId, [FromBody] ServerSettings updated) {
-            var existing = await _db.ServerSettings.FirstOrDefaultAsync(s => s.ProjectId == projectId);
+        public async Task<IActionResult> UpdateSettings(Guid projectId, [FromBody] ProjectSettings updated) {
+            var existing = await _db.ProjectSettings.FirstOrDefaultAsync(s => s.ProjectId == projectId);
             if (existing == null)
             {
                 updated.Id = Guid.NewGuid();
                 updated.ProjectId = projectId;
-                _db.ServerSettings.Add(updated);
+                _db.ProjectSettings.Add(updated);
             }
             else
             {

--- a/SFServer.API/Controllers/ProjectSettingsController.cs
+++ b/SFServer.API/Controllers/ProjectSettingsController.cs
@@ -33,6 +33,8 @@ namespace SFServer.API.Controllers {
             {
                 updated.Id = Guid.NewGuid();
                 updated.ProjectId = projectId;
+                if (updated.BundleId == null)
+                    updated.BundleId = string.Empty;
                 _db.ProjectSettings.Add(updated);
             }
             else
@@ -42,6 +44,7 @@ namespace SFServer.API.Controllers {
                 existing.GoogleClientId = updated.GoogleClientId;
                 existing.GoogleClientSecret = updated.GoogleClientSecret;
                 existing.ClickHouseConnection = updated.ClickHouseConnection;
+                existing.BundleId = updated.BundleId;
                 if (string.IsNullOrEmpty(updated.GoogleServiceAccountJson) == false) {
                     dynamic parsedJson = JsonConvert.DeserializeObject(updated.GoogleServiceAccountJson);
                     existing.GoogleServiceAccountJson = parsedJson == null ? updated.GoogleServiceAccountJson : (string)JsonConvert.SerializeObject(parsedJson, Formatting.Indented);

--- a/SFServer.API/Controllers/ProjectSettingsController.cs
+++ b/SFServer.API/Controllers/ProjectSettingsController.cs
@@ -31,7 +31,7 @@ namespace SFServer.API.Controllers {
             var existing = await _db.ProjectSettings.FirstOrDefaultAsync(s => s.ProjectId == projectId);
             if (existing == null)
             {
-                updated.Id = Guid.NewGuid();
+                updated.Id = Guid.CreateVersion7();
                 updated.ProjectId = projectId;
                 if (updated.BundleId == null)
                     updated.BundleId = string.Empty;

--- a/SFServer.API/Controllers/ProjectsController.cs
+++ b/SFServer.API/Controllers/ProjectsController.cs
@@ -62,6 +62,30 @@ public class ProjectsController : ControllerBase
         var project = await _db.Projects.FindAsync(id);
         if (project == null)
             return NotFound();
+        // Remove all records that belong to the project before deleting it
+        var profiles = _db.UserProfiles.Where(p => p.ProjectId == id);
+        _db.UserProfiles.RemoveRange(profiles);
+
+        var devices = _db.UserDevices.Where(d => d.ProjectId == id);
+        _db.UserDevices.RemoveRange(devices);
+
+        var currencies = _db.Currencies.Where(c => c.ProjectId == id);
+        _db.Currencies.RemoveRange(currencies);
+
+        var wallets = _db.WalletItems.Where(w => w.ProjectId == id);
+        _db.WalletItems.RemoveRange(wallets);
+
+        var inventoryItems = _db.InventoryItems.Where(i => i.ProjectId == id);
+        _db.InventoryItems.RemoveRange(inventoryItems);
+
+        var playerInventory = _db.PlayerInventoryItems.Where(pi => pi.ProjectId == id);
+        _db.PlayerInventoryItems.RemoveRange(playerInventory);
+
+        var settings = _db.ProjectSettings.Where(s => s.ProjectId == id);
+        _db.ProjectSettings.RemoveRange(settings);
+
+        var logs = _db.AuditLogs.Where(l => l.ProjectId == id);
+        _db.AuditLogs.RemoveRange(logs);
 
         _db.Projects.Remove(project);
         await _db.SaveChangesAsync();

--- a/SFServer.API/Controllers/ProjectsController.cs
+++ b/SFServer.API/Controllers/ProjectsController.cs
@@ -1,0 +1,51 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using SFServer.API.Data;
+using SFServer.Shared.Server.Project;
+
+namespace SFServer.API.Controllers;
+
+[ApiController]
+[Route("[controller]")]
+[Authorize(Roles = "Admin,Developer")]
+public class ProjectsController : ControllerBase
+{
+    private readonly DatabseContext _db;
+
+    public ProjectsController(DatabseContext db)
+    {
+        _db = db;
+    }
+
+    [HttpGet]
+    [AllowAnonymous]
+    public async Task<IActionResult> GetAll()
+    {
+        var list = await _db.Projects.ToListAsync();
+        return Ok(list);
+    }
+
+    [HttpPost]
+    [Authorize(Roles = "Admin")]
+    public async Task<IActionResult> Create([FromBody] ProjectInfo project)
+    {
+        project.Id = Guid.NewGuid();
+        _db.Projects.Add(project);
+        await _db.SaveChangesAsync();
+        return CreatedAtAction(nameof(GetAll), new { id = project.Id }, project);
+    }
+
+    [HttpDelete("{id:guid}")]
+    [Authorize(Roles = "Admin")]
+    public async Task<IActionResult> Delete(Guid id)
+    {
+        var project = await _db.Projects.FindAsync(id);
+        if (project == null)
+            return NotFound();
+
+        _db.Projects.Remove(project);
+        await _db.SaveChangesAsync();
+        return NoContent();
+    }
+}

--- a/SFServer.API/Controllers/ProjectsController.cs
+++ b/SFServer.API/Controllers/ProjectsController.cs
@@ -36,10 +36,29 @@ public class ProjectsController : ControllerBase
         return CreatedAtAction(nameof(GetAll), new { id = project.Id }, project);
     }
 
+    [HttpPut("{id:guid}")]
+    [Authorize(Roles = "Admin")]
+    public async Task<IActionResult> Rename(Guid id, [FromBody] ProjectInfo project)
+    {
+        if (id != project.Id)
+            return BadRequest();
+
+        var existing = await _db.Projects.FindAsync(id);
+        if (existing == null)
+            return NotFound();
+
+        existing.Name = project.Name;
+        await _db.SaveChangesAsync();
+        return NoContent();
+    }
+
     [HttpDelete("{id:guid}")]
     [Authorize(Roles = "Admin")]
     public async Task<IActionResult> Delete(Guid id)
     {
+        if (id == Guid.Empty)
+            return BadRequest("Cannot delete default project");
+
         var project = await _db.Projects.FindAsync(id);
         if (project == null)
             return NotFound();

--- a/SFServer.API/Controllers/ProjectsController.cs
+++ b/SFServer.API/Controllers/ProjectsController.cs
@@ -9,28 +9,24 @@ namespace SFServer.API.Controllers;
 [ApiController]
 [Route("[controller]")]
 [Authorize(Roles = "Admin,Developer")]
-public class ProjectsController : ControllerBase
-{
+public class ProjectsController : ControllerBase {
     private readonly DatabseContext _db;
 
-    public ProjectsController(DatabseContext db)
-    {
+    public ProjectsController(DatabseContext db) {
         _db = db;
     }
 
     [HttpGet]
     [AllowAnonymous]
-    public async Task<IActionResult> GetAll()
-    {
+    public async Task<IActionResult> GetAll() {
         var list = await _db.Projects.ToListAsync();
         return Ok(list);
     }
 
     [HttpPost]
     [Authorize(Roles = "Admin")]
-    public async Task<IActionResult> Create([FromBody] ProjectInfo project)
-    {
-        project.Id = Guid.NewGuid();
+    public async Task<IActionResult> Create([FromBody] ProjectInfo project) {
+        project.Id = Guid.CreateVersion7();
         _db.Projects.Add(project);
         await _db.SaveChangesAsync();
         return CreatedAtAction(nameof(GetAll), new { id = project.Id }, project);
@@ -38,8 +34,7 @@ public class ProjectsController : ControllerBase
 
     [HttpPut("{id:guid}")]
     [Authorize(Roles = "Admin")]
-    public async Task<IActionResult> Rename(Guid id, [FromBody] ProjectInfo project)
-    {
+    public async Task<IActionResult> Rename(Guid id, [FromBody] ProjectInfo project) {
         if (id != project.Id)
             return BadRequest();
 
@@ -54,11 +49,10 @@ public class ProjectsController : ControllerBase
 
     [HttpDelete("{id:guid}")]
     [Authorize(Roles = "Admin")]
-    public async Task<IActionResult> Delete(Guid id)
-    {
-        if (id == Guid.Empty)
-            return BadRequest();
-
+    public async Task<IActionResult> Delete(Guid id) {
+        var count = await _db.Projects.CountAsync();
+        if (count == 1) return BadRequest();
+        
         var project = await _db.Projects.FindAsync(id);
         if (project == null)
             return NotFound();

--- a/SFServer.API/Controllers/ProjectsController.cs
+++ b/SFServer.API/Controllers/ProjectsController.cs
@@ -63,22 +63,24 @@ public class ProjectsController : ControllerBase
         if (project == null)
             return NotFound();
         // Remove all records that belong to the project before deleting it
-        var profiles = _db.UserProfiles.Where(p => p.ProjectId == id);
+        var profiles = _db.UserProfiles.Where(p => p.ProjectId == id).ToList();
         _db.UserProfiles.RemoveRange(profiles);
 
-        var devices = _db.UserDevices.Where(d => d.ProjectId == id);
+        var userIds = profiles.Select(p => p.Id).ToList();
+
+        var devices = _db.UserDevices.Where(d => userIds.Contains(d.UserId));
         _db.UserDevices.RemoveRange(devices);
 
         var currencies = _db.Currencies.Where(c => c.ProjectId == id);
         _db.Currencies.RemoveRange(currencies);
 
-        var wallets = _db.WalletItems.Where(w => w.ProjectId == id);
+        var wallets = _db.WalletItems.Where(w => userIds.Contains(w.UserId));
         _db.WalletItems.RemoveRange(wallets);
 
         var inventoryItems = _db.InventoryItems.Where(i => i.ProjectId == id);
         _db.InventoryItems.RemoveRange(inventoryItems);
 
-        var playerInventory = _db.PlayerInventoryItems.Where(pi => pi.ProjectId == id);
+        var playerInventory = _db.PlayerInventoryItems.Where(pi => userIds.Contains(pi.UserId));
         _db.PlayerInventoryItems.RemoveRange(playerInventory);
 
         var settings = _db.ProjectSettings.Where(s => s.ProjectId == id);

--- a/SFServer.API/Controllers/ProjectsController.cs
+++ b/SFServer.API/Controllers/ProjectsController.cs
@@ -57,7 +57,7 @@ public class ProjectsController : ControllerBase
     public async Task<IActionResult> Delete(Guid id)
     {
         if (id == Guid.Empty)
-            return BadRequest("Cannot delete default project");
+            return BadRequest();
 
         var project = await _db.Projects.FindAsync(id);
         if (project == null)

--- a/SFServer.API/Controllers/PurchasesController.cs
+++ b/SFServer.API/Controllers/PurchasesController.cs
@@ -30,7 +30,7 @@ public class PurchasesController : ControllerBase
         if (!ModelState.IsValid)
             return BadRequest(ModelState);
 
-        var settings = await _db.ServerSettings.FirstOrDefaultAsync();
+        var settings = await _db.GlobalSettings.FirstOrDefaultAsync();
         var credJson = settings?.GoogleServiceAccountJson;
         if (string.IsNullOrEmpty(credJson))
             credJson = _config["GOOGLE_SERVICE_ACCOUNT_JSON"];

--- a/SFServer.API/Controllers/PurchasesController.cs
+++ b/SFServer.API/Controllers/PurchasesController.cs
@@ -75,7 +75,7 @@ public class PurchasesController : ControllerBase
                         {
                             _db.PlayerInventoryItems.Add(new PlayerInventoryItem
                             {
-                                Id = Guid.NewGuid(),
+                                Id = Guid.CreateVersion7(),
                                 UserId = userId,
                                 ItemId = item.Id,
                                 Amount = 1

--- a/SFServer.API/Controllers/PurchasesController.cs
+++ b/SFServer.API/Controllers/PurchasesController.cs
@@ -11,7 +11,7 @@ using SFServer.Shared.Server.Inventory;
 namespace SFServer.API.Controllers;
 
 [ApiController]
-[Route("[controller]")]
+[Route("{projectId:guid}/[controller]")]
 [Authorize]
 public class PurchasesController : ControllerBase
 {
@@ -25,12 +25,12 @@ public class PurchasesController : ControllerBase
     }
 
     [HttpPost("validate-android")]
-    public async Task<IActionResult> ValidateAndroid([FromBody] AndroidPurchaseValidationRequest request)
+    public async Task<IActionResult> ValidateAndroid(Guid projectId, [FromBody] AndroidPurchaseValidationRequest request)
     {
         if (!ModelState.IsValid)
             return BadRequest(ModelState);
 
-        var settings = await _db.GlobalSettings.FirstOrDefaultAsync();
+        var settings = await _db.ProjectSettings.FirstOrDefaultAsync(s => s.ProjectId == projectId);
         var credJson = settings?.GoogleServiceAccountJson;
         if (string.IsNullOrEmpty(credJson))
             credJson = _config["GOOGLE_SERVICE_ACCOUNT_JSON"];

--- a/SFServer.API/Controllers/ServerSettingsController.cs
+++ b/SFServer.API/Controllers/ServerSettingsController.cs
@@ -8,7 +8,7 @@ using SFServer.Shared.Server.Settings;
 
 namespace SFServer.API.Controllers {
     [ApiController]
-    [Route("[controller]")]
+    [Route("{projectId:guid}/[controller]")]
     [Authorize(Roles = "Admin")]
     public class ServerSettingsController : ControllerBase {
         private readonly DatabseContext _db;
@@ -19,9 +19,7 @@ namespace SFServer.API.Controllers {
 
         [HttpGet]
         [AllowAnonymous]
-        public async Task<IActionResult> GetSettings() {
-            if (!Guid.TryParse(Request.Headers[Headers.PID], out var projectId))
-                return BadRequest("ProjectId header required");
+        public async Task<IActionResult> GetSettings(Guid projectId) {
             var settings = await _db.ServerSettings.FirstOrDefaultAsync(s => s.ProjectId == projectId);
             if (settings == null)
                 return NotFound();
@@ -29,9 +27,7 @@ namespace SFServer.API.Controllers {
         }
 
         [HttpPut]
-        public async Task<IActionResult> UpdateSettings([FromBody] ServerSettings updated) {
-            if (!Guid.TryParse(Request.Headers[Headers.PID], out var projectId))
-                return BadRequest("ProjectId header required");
+        public async Task<IActionResult> UpdateSettings(Guid projectId, [FromBody] ServerSettings updated) {
             var existing = await _db.ServerSettings.FirstOrDefaultAsync(s => s.ProjectId == projectId);
             if (existing == null)
             {

--- a/SFServer.API/Controllers/StatisticsController.cs
+++ b/SFServer.API/Controllers/StatisticsController.cs
@@ -7,7 +7,7 @@ using SFServer.Shared.Server.Statistics;
 namespace SFServer.API.Controllers
 {
     [ApiController]
-    [Route("[controller]")]
+    [Route("{projectId:guid}/[controller]")]
     [Authorize(Roles = "Admin,Developer")]
     public class StatisticsController : ControllerBase
     {
@@ -19,10 +19,8 @@ namespace SFServer.API.Controllers
         }
 
         [HttpGet]
-        public async Task<IActionResult> GetStatistics()
+        public async Task<IActionResult> GetStatistics(Guid projectId)
         {
-            if (!Guid.TryParse(Request.Headers[Headers.PID], out var projectId))
-                return BadRequest("ProjectId header required");
 
             var totalUsers = await _db.UserProfiles.CountAsync(u => u.ProjectId == projectId);
             var now = DateTime.UtcNow;

--- a/SFServer.API/Controllers/UserProfilesController.cs
+++ b/SFServer.API/Controllers/UserProfilesController.cs
@@ -139,25 +139,6 @@ namespace SFServer.API.Controllers
             existing.DebugMode = updated.DebugMode;
             updated.ProjectId = existing.ProjectId;
 
-            // Determine if current user is trying to change someone else's password
-            var currentUserId = Request.Headers[Headers.UID].FirstOrDefault();
-            if (string.IsNullOrEmpty(currentUserId))
-            {
-                currentUserId = User.FindFirst("UserId")?.Value;
-            }
-            bool isSelf = currentUserId == existing.Id.ToString();
-            bool isAdmin = User.IsInRole("Admin");
-
-            if (!string.IsNullOrEmpty(updated.PasswordHash))
-            {
-                if (!isAdmin && !isSelf)
-                {
-                    return Forbid("You can only change your own password.");
-                }
-
-                // Only allow Admin or self to update password
-                existing.PasswordHash = updated.PasswordHash;
-            }
 
             try
             {

--- a/SFServer.API/Controllers/UserProfilesController.cs
+++ b/SFServer.API/Controllers/UserProfilesController.cs
@@ -92,7 +92,7 @@ namespace SFServer.API.Controllers
         [HttpGet("{userId:guid}/device/{deviceId}")]
         public async Task<IActionResult> GetDeviceById(Guid projectId, Guid userId, string deviceId)
         {
-            var userDevice = await _db.UserDevices.FirstOrDefaultAsync(d => d.UserId == userId && d.DeviceId == deviceId && d.ProjectId == projectId);
+            var userDevice = await _db.UserDevices.FirstOrDefaultAsync(d => d.UserId == userId && d.DeviceId == deviceId);
             if (userDevice == null)
             {
                 Console.WriteLine($"Device {deviceId} for user {userId} not found");

--- a/SFServer.API/Controllers/UserProfilesController.cs
+++ b/SFServer.API/Controllers/UserProfilesController.cs
@@ -7,7 +7,7 @@ using SFServer.Shared.Server.UserProfile;
 namespace SFServer.API.Controllers
 {
     [ApiController]
-    [Route("[controller]")]
+    [Route("{projectId:guid}/[controller]")]
     [Authorize(Roles = "Admin,Developer")]
     public class UserProfilesController : ControllerBase
     {
@@ -20,17 +20,15 @@ namespace SFServer.API.Controllers
 
         // GET: api/UserProfiles
         [HttpGet]
-        public async Task<IActionResult> GetUserProfiles()
+        public async Task<IActionResult> GetUserProfiles(Guid projectId)
         {
-            if (!Guid.TryParse(Request.Headers[Headers.PID], out var projectId))
-                return BadRequest("ProjectId header required");
             var profiles = await _db.UserProfiles.Where(p => p.ProjectId == projectId).ToListAsync();
             return Ok(profiles);
         }
 
         // POST: api/UserProfiles
         [HttpPost]
-        public async Task<IActionResult> CreateUserProfile([FromBody] UserProfile profile)
+        public async Task<IActionResult> CreateUserProfile(Guid projectId, [FromBody] UserProfile profile)
         {
             if (profile == null)
             {
@@ -49,9 +47,6 @@ namespace SFServer.API.Controllers
                 return BadRequest("Email already exists.");
             }
 
-            if (!Guid.TryParse(Request.Headers[Headers.PID], out var projectId))
-                return BadRequest("ProjectId header required");
-
             profile.CreatedAt = DateTime.UtcNow;
             profile.ProjectId = projectId;
             _db.UserProfiles.Add(profile);
@@ -64,10 +59,8 @@ namespace SFServer.API.Controllers
 
         [HttpDelete("{id:guid}")]
         [Authorize(Roles = "Admin")]
-        public async Task<IActionResult> Delete(Guid id)
+        public async Task<IActionResult> Delete(Guid projectId, Guid id)
         {
-            if (!Guid.TryParse(Request.Headers[Headers.PID], out var projectId))
-                return BadRequest("ProjectId header required");
             var profile = await _db.UserProfiles.FirstOrDefaultAsync(u => u.Id == id && u.ProjectId == projectId);
             if (profile == null)
                 return NotFound();
@@ -88,10 +81,8 @@ namespace SFServer.API.Controllers
 
         // GET: api/UserProfiles/{id}
         [HttpGet("{id:guid}")]
-        public async Task<IActionResult> GetById(Guid id)
+        public async Task<IActionResult> GetById(Guid projectId, Guid id)
         {
-            if (!Guid.TryParse(Request.Headers[Headers.PID], out var projectId))
-                return BadRequest("ProjectId header required");
             var user = await _db.UserProfiles.FirstOrDefaultAsync(u => u.Id == id && u.ProjectId == projectId);
             if (user == null) return NotFound();
             return Ok(user);
@@ -99,10 +90,8 @@ namespace SFServer.API.Controllers
 
         // GET: api/UserProfiles/{userId}/device/{deviceId}
         [HttpGet("{userId:guid}/device/{deviceId}")]
-        public async Task<IActionResult> GetDeviceById(Guid userId, string deviceId)
+        public async Task<IActionResult> GetDeviceById(Guid projectId, Guid userId, string deviceId)
         {
-            if (!Guid.TryParse(Request.Headers[Headers.PID], out var projectId))
-                return BadRequest("ProjectId header required");
             var userDevice = await _db.UserDevices.FirstOrDefaultAsync(d => d.UserId == userId && d.DeviceId == deviceId && d.ProjectId == projectId);
             if (userDevice == null)
             {
@@ -114,10 +103,8 @@ namespace SFServer.API.Controllers
         }
 
         [HttpPut("{id:guid}")]
-        public async Task<IActionResult> UpdateUserProfile(Guid id, [FromBody] UserProfile updated)
+        public async Task<IActionResult> UpdateUserProfile(Guid projectId, Guid id, [FromBody] UserProfile updated)
         {
-            if (!Guid.TryParse(Request.Headers[Headers.PID], out var projectId))
-                return BadRequest("ProjectId header required");
             if (id != updated.Id)
             {
                 return BadRequest("ID mismatch.");

--- a/SFServer.API/Controllers/WalletController.cs
+++ b/SFServer.API/Controllers/WalletController.cs
@@ -29,7 +29,7 @@ namespace SFServer.API.Controllers
 
             // Retrieve existing wallet items for the user.
             var walletItems = await _context.WalletItems
-                .Where(w => w.UserId == userId && w.ProjectId == projectId)
+                .Where(w => w.UserId == userId)
                 .Include(w => w.Currency)
                 .ToListAsync();
 
@@ -43,8 +43,7 @@ namespace SFServer.API.Controllers
                         UserId = userId,
                         CurrencyId = currency.Id,
                         Amount = currency.InitialAmount,
-                        Currency = currency,
-                        ProjectId = projectId
+                        Currency = currency
                     };
                     _context.WalletItems.Add(newItem);
                     walletItems.Add(newItem);
@@ -67,7 +66,7 @@ namespace SFServer.API.Controllers
 
 
             var existingItem = await _context.WalletItems
-                .FirstOrDefaultAsync(w => w.Id == walletItemId && w.ProjectId == projectId);
+                .FirstOrDefaultAsync(w => w.Id == walletItemId);
             if (existingItem == null)
             {
                 Console.WriteLine("Wallet item not found.");
@@ -92,7 +91,7 @@ namespace SFServer.API.Controllers
             foreach (var updateDto in updateDtos)
             {
                 var existingItem = await _context.WalletItems
-                    .FirstOrDefaultAsync(w => w.Id == updateDto.Id && w.ProjectId == projectId);
+                    .FirstOrDefaultAsync(w => w.Id == updateDto.Id);
                 if (existingItem == null)
                 {
                     Console.WriteLine($"Wallet item not found for ID: {updateDto.Id}");

--- a/SFServer.API/Controllers/WalletController.cs
+++ b/SFServer.API/Controllers/WalletController.cs
@@ -7,7 +7,7 @@ using SFServer.Shared.Server.Wallet;
 namespace SFServer.API.Controllers
 {
     [ApiController]
-    [Route("[controller]")]
+    [Route("{projectId:guid}/[controller]")]
     [Authorize] // Requires authentication.
     public class WalletController : ControllerBase
     {
@@ -19,10 +19,8 @@ namespace SFServer.API.Controllers
         
         // GET /Wallet/{userId}
         [HttpGet("{userId}")]
-        public async Task<IActionResult> GetWallet(Guid userId)
+        public async Task<IActionResult> GetWallet(Guid projectId, Guid userId)
         {
-            if (!Guid.TryParse(Request.Headers[Headers.PID], out var projectId))
-                return BadRequest("ProjectId header required");
 
             // Retrieve all system currencies for project.
             var currencies = await _context.Currencies
@@ -59,7 +57,7 @@ namespace SFServer.API.Controllers
         
         // PUT /Wallet/{walletItemId}
         [HttpPut("{walletItemId:guid}")]
-        public async Task<IActionResult> UpdateWalletItem(Guid walletItemId, [FromBody] WalletUpdateDto updateDto)
+        public async Task<IActionResult> UpdateWalletItem(Guid projectId, Guid walletItemId, [FromBody] WalletUpdateDto updateDto)
         {
             if (walletItemId != updateDto.Id)
             {
@@ -67,8 +65,6 @@ namespace SFServer.API.Controllers
                 return BadRequest("ID mismatch.");
             }
 
-            if (!Guid.TryParse(Request.Headers[Headers.PID], out var projectId))
-                return BadRequest("ProjectId header required");
 
             var existingItem = await _context.WalletItems
                 .FirstOrDefaultAsync(w => w.Id == walletItemId && w.ProjectId == projectId);
@@ -85,15 +81,13 @@ namespace SFServer.API.Controllers
         
         // PUT /Wallet/batch
         [HttpPut("batch")]
-        public async Task<IActionResult> UpdateWalletItems([FromBody] List<WalletUpdateDto> updateDtos)
+        public async Task<IActionResult> UpdateWalletItems(Guid projectId, [FromBody] List<WalletUpdateDto> updateDtos)
         {
             if (updateDtos == null || updateDtos.Count == 0)
             {
                 return BadRequest("No wallet items provided for update.");
             }
 
-            if (!Guid.TryParse(Request.Headers[Headers.PID], out var projectId))
-                return BadRequest("ProjectId header required");
 
             foreach (var updateDto in updateDtos)
             {

--- a/SFServer.API/Data/DatabseContext.cs
+++ b/SFServer.API/Data/DatabseContext.cs
@@ -28,7 +28,8 @@ namespace SFServer.API.Data
 
         public DbSet<UserSession> UserSessions { get; set; }
 
-        public DbSet<ServerSettings> ServerSettings { get; set; }
+        public DbSet<ProjectSettings> ProjectSettings { get; set; }
+        public DbSet<GlobalSettings> GlobalSettings { get; set; }
 
         public DbSet<AuditLogEntry> AuditLogs { get; set; }
 

--- a/SFServer.API/Data/DatabseContext.cs
+++ b/SFServer.API/Data/DatabseContext.cs
@@ -5,6 +5,7 @@ using SFServer.Shared.Server.Wallet;
 using SFServer.Shared.Server.Inventory;
 using SFServer.Shared.Server.Settings;
 using SFServer.Shared.Server.Audit;
+using SFServer.Shared.Server.Project;
 
 namespace SFServer.API.Data
 {
@@ -18,6 +19,8 @@ namespace SFServer.API.Data
         public DbSet<WalletItem> WalletItems { get; set; }
         public DbSet<Currency> Currencies { get; set; }
 
+        public DbSet<ProjectInfo> Projects { get; set; }
+
         public DbSet<UserDevice> UserDevices { get; set; }
 
         public DbSet<InventoryItem> InventoryItems { get; set; }
@@ -28,6 +31,8 @@ namespace SFServer.API.Data
         public DbSet<ServerSettings> ServerSettings { get; set; }
 
         public DbSet<AuditLogEntry> AuditLogs { get; set; }
+
+        public DbSet<SFServer.Shared.Server.Admin.Administrator> Administrators { get; set; }
 
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)

--- a/SFServer.API/Headers.cs
+++ b/SFServer.API/Headers.cs
@@ -1,5 +1,6 @@
 ﻿namespace SFServer.API {
     public static class Headers {
         public const string UID = "UserId";
+        public const string PID = "ProjectId";
     }
 }

--- a/SFServer.API/Migrations/20250715222859_AddProjectSupport.Designer.cs
+++ b/SFServer.API/Migrations/20250715222859_AddProjectSupport.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SFServer.API.Data;
@@ -12,9 +13,11 @@ using SFServer.API.Data;
 namespace SFServer.API.Migrations
 {
     [DbContext(typeof(DatabseContext))]
-    partial class UserProfilesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250715222859_AddProjectSupport")]
+    partial class AddProjectSupport
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -46,29 +49,6 @@ namespace SFServer.API.Migrations
                     b.HasKey("Id");
 
                     b.ToTable("UserSessions");
-                });
-
-            modelBuilder.Entity("SFServer.Shared.Server.Admin.Administrator", b =>
-                {
-                    b.Property<Guid>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("uuid");
-
-                    b.Property<DateTime>("CreatedAt")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<string>("Email")
-                        .HasColumnType("text");
-
-                    b.Property<string>("PasswordHash")
-                        .HasColumnType("text");
-
-                    b.Property<string>("Username")
-                        .HasColumnType("text");
-
-                    b.HasKey("Id");
-
-                    b.ToTable("Administrators");
                 });
 
             modelBuilder.Entity("SFServer.Shared.Server.Audit.AuditLogEntry", b =>

--- a/SFServer.API/Migrations/20250715222859_AddProjectSupport.cs
+++ b/SFServer.API/Migrations/20250715222859_AddProjectSupport.cs
@@ -1,0 +1,122 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SFServer.API.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddProjectSupport : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "ProjectId",
+                table: "WalletItems",
+                type: "uuid",
+                nullable: false,
+                defaultValue: new Guid("00000000-0000-0000-0000-000000000000"));
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "ProjectId",
+                table: "UserProfiles",
+                type: "uuid",
+                nullable: false,
+                defaultValue: new Guid("00000000-0000-0000-0000-000000000000"));
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "ProjectId",
+                table: "UserDevices",
+                type: "uuid",
+                nullable: false,
+                defaultValue: new Guid("00000000-0000-0000-0000-000000000000"));
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "ProjectId",
+                table: "ServerSettings",
+                type: "uuid",
+                nullable: false,
+                defaultValue: new Guid("00000000-0000-0000-0000-000000000000"));
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "ProjectId",
+                table: "PlayerInventoryItems",
+                type: "uuid",
+                nullable: false,
+                defaultValue: new Guid("00000000-0000-0000-0000-000000000000"));
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "ProjectId",
+                table: "InventoryItems",
+                type: "uuid",
+                nullable: false,
+                defaultValue: new Guid("00000000-0000-0000-0000-000000000000"));
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "ProjectId",
+                table: "Currencies",
+                type: "uuid",
+                nullable: false,
+                defaultValue: new Guid("00000000-0000-0000-0000-000000000000"));
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "ProjectId",
+                table: "AuditLogs",
+                type: "uuid",
+                nullable: false,
+                defaultValue: new Guid("00000000-0000-0000-0000-000000000000"));
+
+            migrationBuilder.CreateTable(
+                name: "Projects",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    Name = table.Column<string>(type: "text", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Projects", x => x.Id);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Projects");
+
+            migrationBuilder.DropColumn(
+                name: "ProjectId",
+                table: "WalletItems");
+
+            migrationBuilder.DropColumn(
+                name: "ProjectId",
+                table: "UserProfiles");
+
+            migrationBuilder.DropColumn(
+                name: "ProjectId",
+                table: "UserDevices");
+
+            migrationBuilder.DropColumn(
+                name: "ProjectId",
+                table: "ServerSettings");
+
+            migrationBuilder.DropColumn(
+                name: "ProjectId",
+                table: "PlayerInventoryItems");
+
+            migrationBuilder.DropColumn(
+                name: "ProjectId",
+                table: "InventoryItems");
+
+            migrationBuilder.DropColumn(
+                name: "ProjectId",
+                table: "Currencies");
+
+            migrationBuilder.DropColumn(
+                name: "ProjectId",
+                table: "AuditLogs");
+        }
+    }
+}

--- a/SFServer.API/Migrations/20250718003620_AddAdministrators.Designer.cs
+++ b/SFServer.API/Migrations/20250718003620_AddAdministrators.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SFServer.API.Data;
@@ -12,9 +13,11 @@ using SFServer.API.Data;
 namespace SFServer.API.Migrations
 {
     [DbContext(typeof(DatabseContext))]
-    partial class UserProfilesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250718003620_AddAdministrators")]
+    partial class AddAdministrators
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/SFServer.API/Migrations/20250718003620_AddAdministrators.cs
+++ b/SFServer.API/Migrations/20250718003620_AddAdministrators.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SFServer.API.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddAdministrators : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Administrators",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    Username = table.Column<string>(type: "text", nullable: true),
+                    Email = table.Column<string>(type: "text", nullable: true),
+                    PasswordHash = table.Column<string>(type: "text", nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Administrators", x => x.Id);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Administrators");
+        }
+    }
+}

--- a/SFServer.API/Migrations/20250718222721_AddGlobalSettings.Designer.cs
+++ b/SFServer.API/Migrations/20250718222721_AddGlobalSettings.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SFServer.API.Data;
@@ -12,9 +13,11 @@ using SFServer.API.Data;
 namespace SFServer.API.Migrations
 {
     [DbContext(typeof(DatabseContext))]
-    partial class UserProfilesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250718222721_AddGlobalSettings")]
+    partial class AddGlobalSettings
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/SFServer.API/Migrations/20250718222721_AddGlobalSettings.cs
+++ b/SFServer.API/Migrations/20250718222721_AddGlobalSettings.cs
@@ -1,0 +1,66 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+using System;
+
+#nullable disable
+
+namespace SFServer.API.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddGlobalSettings : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_ServerSettings",
+                table: "ServerSettings");
+
+            migrationBuilder.RenameTable(
+                name: "ServerSettings",
+                newName: "ProjectSettings");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_ProjectSettings",
+                table: "ProjectSettings",
+                column: "Id");
+
+            migrationBuilder.CreateTable(
+                name: "GlobalSettings",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    ServerTitle = table.Column<string>(type: "text", nullable: true),
+                    ServerCopyright = table.Column<string>(type: "text", nullable: true),
+                    GoogleClientId = table.Column<string>(type: "text", nullable: true),
+                    ClickHouseConnection = table.Column<string>(type: "text", nullable: true),
+                    GoogleClientSecret = table.Column<string>(type: "text", nullable: true),
+                    GoogleServiceAccountJson = table.Column<string>(type: "text", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_GlobalSettings", x => x.Id);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "GlobalSettings");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_ProjectSettings",
+                table: "ProjectSettings");
+
+            migrationBuilder.RenameTable(
+                name: "ProjectSettings",
+                newName: "ServerSettings");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_ServerSettings",
+                table: "ServerSettings",
+                column: "Id");
+        }
+    }
+}
+

--- a/SFServer.API/Migrations/20250719000012_RemoveCredentialsFromGlobalSettings.Designer.cs
+++ b/SFServer.API/Migrations/20250719000012_RemoveCredentialsFromGlobalSettings.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SFServer.API.Data;
@@ -12,9 +13,11 @@ using SFServer.API.Data;
 namespace SFServer.API.Migrations
 {
     [DbContext(typeof(DatabseContext))]
-    partial class UserProfilesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250719000012_RemoveCredentialsFromGlobalSettings")]
+    partial class RemoveCredentialsFromGlobalSettings
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/SFServer.API/Migrations/20250719000012_RemoveCredentialsFromGlobalSettings.cs
+++ b/SFServer.API/Migrations/20250719000012_RemoveCredentialsFromGlobalSettings.cs
@@ -1,0 +1,58 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SFServer.API.Migrations
+{
+    /// <inheritdoc />
+    public partial class RemoveCredentialsFromGlobalSettings : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ClickHouseConnection",
+                table: "GlobalSettings");
+
+            migrationBuilder.DropColumn(
+                name: "GoogleClientId",
+                table: "GlobalSettings");
+
+            migrationBuilder.DropColumn(
+                name: "GoogleClientSecret",
+                table: "GlobalSettings");
+
+            migrationBuilder.DropColumn(
+                name: "GoogleServiceAccountJson",
+                table: "GlobalSettings");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "ClickHouseConnection",
+                table: "GlobalSettings",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "GoogleClientId",
+                table: "GlobalSettings",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "GoogleClientSecret",
+                table: "GlobalSettings",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "GoogleServiceAccountJson",
+                table: "GlobalSettings",
+                type: "text",
+                nullable: true);
+        }
+    }
+}

--- a/SFServer.API/Migrations/20250721191521_RemoveProjectIdFromItems.Designer.cs
+++ b/SFServer.API/Migrations/20250721191521_RemoveProjectIdFromItems.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SFServer.API.Data;
@@ -12,9 +13,11 @@ using SFServer.API.Data;
 namespace SFServer.API.Migrations
 {
     [DbContext(typeof(DatabseContext))]
-    partial class UserProfilesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250721191521_RemoveProjectIdFromItems")]
+    partial class RemoveProjectIdFromItems
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/SFServer.API/Migrations/20250721191521_RemoveProjectIdFromItems.cs
+++ b/SFServer.API/Migrations/20250721191521_RemoveProjectIdFromItems.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SFServer.API.Migrations
+{
+    /// <inheritdoc />
+    public partial class RemoveProjectIdFromItems : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ProjectId",
+                table: "WalletItems");
+
+            migrationBuilder.DropColumn(
+                name: "ProjectId",
+                table: "UserDevices");
+
+            migrationBuilder.DropColumn(
+                name: "ProjectId",
+                table: "PlayerInventoryItems");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "ProjectId",
+                table: "WalletItems",
+                type: "uuid",
+                nullable: false,
+                defaultValue: new Guid("00000000-0000-0000-0000-000000000000"));
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "ProjectId",
+                table: "UserDevices",
+                type: "uuid",
+                nullable: false,
+                defaultValue: new Guid("00000000-0000-0000-0000-000000000000"));
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "ProjectId",
+                table: "PlayerInventoryItems",
+                type: "uuid",
+                nullable: false,
+                defaultValue: new Guid("00000000-0000-0000-0000-000000000000"));
+        }
+    }
+}

--- a/SFServer.API/Migrations/20250721222727_RemoveUserProfilePassword.Designer.cs
+++ b/SFServer.API/Migrations/20250721222727_RemoveUserProfilePassword.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SFServer.API.Data;
@@ -12,9 +13,11 @@ using SFServer.API.Data;
 namespace SFServer.API.Migrations
 {
     [DbContext(typeof(DatabseContext))]
-    partial class UserProfilesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250721222727_RemoveUserProfilePassword")]
+    partial class RemoveUserProfilePassword
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/SFServer.API/Migrations/20250721222727_RemoveUserProfilePassword.cs
+++ b/SFServer.API/Migrations/20250721222727_RemoveUserProfilePassword.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SFServer.API.Migrations
+{
+    /// <inheritdoc />
+    public partial class RemoveUserProfilePassword : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "PasswordHash",
+                table: "UserProfiles");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "PasswordHash",
+                table: "UserProfiles",
+                type: "text",
+                nullable: true);
+        }
+    }
+}

--- a/SFServer.API/Migrations/20250721234521_AddBundleIdToProjectSettings.Designer.cs
+++ b/SFServer.API/Migrations/20250721234521_AddBundleIdToProjectSettings.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SFServer.API.Data;
@@ -12,9 +13,11 @@ using SFServer.API.Data;
 namespace SFServer.API.Migrations
 {
     [DbContext(typeof(DatabseContext))]
-    partial class UserProfilesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250721234521_AddBundleIdToProjectSettings")]
+    partial class AddBundleIdToProjectSettings
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/SFServer.API/Migrations/20250721234521_AddBundleIdToProjectSettings.cs
+++ b/SFServer.API/Migrations/20250721234521_AddBundleIdToProjectSettings.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SFServer.API.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddBundleIdToProjectSettings : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "BundleId",
+                table: "ProjectSettings",
+                type: "text",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "BundleId",
+                table: "ProjectSettings");
+        }
+    }
+}

--- a/SFServer.API/Migrations/UserProfilesDbContextModelSnapshot.cs
+++ b/SFServer.API/Migrations/UserProfilesDbContextModelSnapshot.cs
@@ -181,7 +181,7 @@ namespace SFServer.API.Migrations
                     b.ToTable("Projects");
                 });
 
-            modelBuilder.Entity("SFServer.Shared.Server.Settings.ServerSettings", b =>
+            modelBuilder.Entity("SFServer.Shared.Server.Settings.ProjectSettings", b =>
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
@@ -210,7 +210,36 @@ namespace SFServer.API.Migrations
 
                     b.HasKey("Id");
 
-                    b.ToTable("ServerSettings");
+                    b.ToTable("ProjectSettings");
+                });
+
+            modelBuilder.Entity("SFServer.Shared.Server.Settings.GlobalSettings", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uuid");
+
+                    b.Property<string>("ClickHouseConnection")
+                        .HasColumnType("text");
+
+                    b.Property<string>("GoogleClientId")
+                        .HasColumnType("text");
+
+                    b.Property<string>("GoogleClientSecret")
+                        .HasColumnType("text");
+
+                    b.Property<string>("GoogleServiceAccountJson")
+                        .HasColumnType("text");
+
+                    b.Property<string>("ServerCopyright")
+                        .HasColumnType("text");
+
+                    b.Property<string>("ServerTitle")
+                        .HasColumnType("text");
+
+                    b.HasKey("Id");
+
+                    b.ToTable("GlobalSettings");
                 });
 
             modelBuilder.Entity("SFServer.Shared.Server.UserProfile.UserDevice", b =>

--- a/SFServer.API/Program.cs
+++ b/SFServer.API/Program.cs
@@ -168,7 +168,7 @@ using (var scope = app.Services.CreateScope())
     {
         project = new SFServer.Shared.Server.Project.ProjectInfo
         {
-            Id = Guid.NewGuid(),
+            Id = Guid.Empty,
             Name = config["DEFAULT_PROJECT_NAME"] ?? "Default"
         };
         context.Projects.Add(project);

--- a/SFServer.API/Program.cs
+++ b/SFServer.API/Program.cs
@@ -183,11 +183,7 @@ using (var scope = app.Services.CreateScope())
         {
             Id = Guid.NewGuid(),
             ServerTitle = config["SERVER_TITLE"] ?? string.Empty,
-            ServerCopyright = config["SERVER_COPYRIGHT"] ?? string.Empty,
-            GoogleClientId = config["GOOGLE_CLIENT_ID"] ?? string.Empty,
-            ClickHouseConnection = config["CLICKHOUSE_CONNECTION"] ?? string.Empty,
-            GoogleClientSecret = config["GOOGLE_CLIENT_SECRET"] ?? string.Empty,
-            GoogleServiceAccountJson = config["GOOGLE_SERVICE_ACCOUNT_JSON"] ?? string.Empty
+            ServerCopyright = config["SERVER_COPYRIGHT"] ?? string.Empty
         };
         context.GlobalSettings.Add(gs);
         context.SaveChanges();

--- a/SFServer.API/Program.cs
+++ b/SFServer.API/Program.cs
@@ -145,7 +145,7 @@ using (var scope = app.Services.CreateScope())
 
         var adminUser = new SFServer.Shared.Server.Admin.Administrator
         {
-            Id = Guid.Empty,
+            Id = Guid.CreateVersion7(),
             Username = adminUsername,
             Email = adminEmail,
             CreatedAt = DateTime.UtcNow
@@ -168,7 +168,7 @@ using (var scope = app.Services.CreateScope())
     {
         project = new SFServer.Shared.Server.Project.ProjectInfo
         {
-            Id = Guid.Empty,
+            Id = Guid.CreateVersion7(),
             Name = config["DEFAULT_PROJECT_NAME"] ?? "Default"
         };
         context.Projects.Add(project);

--- a/SFServer.API/Program.cs
+++ b/SFServer.API/Program.cs
@@ -202,7 +202,8 @@ using (var scope = app.Services.CreateScope())
             GoogleClientId = string.Empty,
             ClickHouseConnection = string.Empty,
             GoogleClientSecret = string.Empty,
-            GoogleServiceAccountJson = string.Empty
+            GoogleServiceAccountJson = string.Empty,
+            BundleId = string.Empty
         };
         context.ProjectSettings.Add(ps);
         context.SaveChanges();

--- a/SFServer.API/Program.cs
+++ b/SFServer.API/Program.cs
@@ -223,22 +223,24 @@ static void CleanupOrphanProjectData(DatabseContext db)
     if (validIds.Count == 0)
         return;
 
-    var profiles = db.UserProfiles.Where(p => !validIds.Contains(p.ProjectId));
-    db.UserProfiles.RemoveRange(profiles);
+    var orphanProfiles = db.UserProfiles.Where(p => !validIds.Contains(p.ProjectId)).ToList();
+    db.UserProfiles.RemoveRange(orphanProfiles);
 
-    var devices = db.UserDevices.Where(d => !validIds.Contains(d.ProjectId));
+    var orphanIds = orphanProfiles.Select(p => p.Id).ToList();
+
+    var devices = db.UserDevices.Where(d => orphanIds.Contains(d.UserId));
     db.UserDevices.RemoveRange(devices);
 
     var currencies = db.Currencies.Where(c => !validIds.Contains(c.ProjectId));
     db.Currencies.RemoveRange(currencies);
 
-    var wallets = db.WalletItems.Where(w => !validIds.Contains(w.ProjectId));
+    var wallets = db.WalletItems.Where(w => orphanIds.Contains(w.UserId));
     db.WalletItems.RemoveRange(wallets);
 
     var items = db.InventoryItems.Where(i => !validIds.Contains(i.ProjectId));
     db.InventoryItems.RemoveRange(items);
 
-    var playerInv = db.PlayerInventoryItems.Where(pi => !validIds.Contains(pi.ProjectId));
+    var playerInv = db.PlayerInventoryItems.Where(pi => orphanIds.Contains(pi.UserId));
     db.PlayerInventoryItems.RemoveRange(playerInv);
 
     var settings = db.ProjectSettings.Where(s => !validIds.Contains(s.ProjectId));

--- a/SFServer.API/Program.cs
+++ b/SFServer.API/Program.cs
@@ -182,7 +182,7 @@ using (var scope = app.Services.CreateScope())
     {
         var gs = new SFServer.Shared.Server.Settings.GlobalSettings
         {
-            Id = Guid.NewGuid(),
+            Id = Guid.CreateVersion7(),
             ServerTitle = config["SERVER_TITLE"] ?? string.Empty,
             ServerCopyright = config["SERVER_COPYRIGHT"] ?? string.Empty
         };
@@ -195,7 +195,7 @@ using (var scope = app.Services.CreateScope())
     {
         var ps = new SFServer.Shared.Server.Settings.ProjectSettings
         {
-            Id = Guid.NewGuid(),
+            Id = Guid.CreateVersion7(),
             ProjectId = project.Id,
             ServerTitle = project.Name,
             ServerCopyright = string.Empty,

--- a/SFServer.API/Program.cs
+++ b/SFServer.API/Program.cs
@@ -176,13 +176,12 @@ using (var scope = app.Services.CreateScope())
         Console.WriteLine("✅ Default project created.");
     }
 
-    // Seed server settings from environment variables if not present
-    if (!context.ServerSettings.Any())
+    // Seed global settings
+    if (!context.GlobalSettings.Any())
     {
-        var settings = new SFServer.Shared.Server.Settings.ServerSettings
+        var gs = new SFServer.Shared.Server.Settings.GlobalSettings
         {
             Id = Guid.NewGuid(),
-            ProjectId = project.Id,
             ServerTitle = config["SERVER_TITLE"] ?? string.Empty,
             ServerCopyright = config["SERVER_COPYRIGHT"] ?? string.Empty,
             GoogleClientId = config["GOOGLE_CLIENT_ID"] ?? string.Empty,
@@ -190,9 +189,27 @@ using (var scope = app.Services.CreateScope())
             GoogleClientSecret = config["GOOGLE_CLIENT_SECRET"] ?? string.Empty,
             GoogleServiceAccountJson = config["GOOGLE_SERVICE_ACCOUNT_JSON"] ?? string.Empty
         };
-        context.ServerSettings.Add(settings);
+        context.GlobalSettings.Add(gs);
         context.SaveChanges();
-        Console.WriteLine("✅ Server settings created from environment.");
+        Console.WriteLine("✅ Global settings created from environment.");
+    }
+
+    if (!context.ProjectSettings.Any())
+    {
+        var ps = new SFServer.Shared.Server.Settings.ProjectSettings
+        {
+            Id = Guid.NewGuid(),
+            ProjectId = project.Id,
+            ServerTitle = project.Name,
+            ServerCopyright = string.Empty,
+            GoogleClientId = string.Empty,
+            ClickHouseConnection = string.Empty,
+            GoogleClientSecret = string.Empty,
+            GoogleServiceAccountJson = string.Empty
+        };
+        context.ProjectSettings.Add(ps);
+        context.SaveChanges();
+        Console.WriteLine("✅ Default project settings created.");
     }
 }
 

--- a/SFServer.API/Services/InventoryService.cs
+++ b/SFServer.API/Services/InventoryService.cs
@@ -13,11 +13,13 @@ namespace SFServer.API.Services
             _db = db;
         }
 
-        public Task<List<InventoryItem>> GetItemsAsync() => _db.InventoryItems.ToListAsync();
+        public Task<List<InventoryItem>> GetItemsAsync(Guid projectId)
+            => _db.InventoryItems.Where(i => i.ProjectId == projectId).ToListAsync();
 
-        public Task<InventoryItem> GetItemAsync(Guid id) => _db.InventoryItems.FindAsync(id).AsTask();
+        public Task<InventoryItem> GetItemAsync(Guid projectId, Guid id)
+            => _db.InventoryItems.FirstOrDefaultAsync(i => i.Id == id && i.ProjectId == projectId);
 
-        public async Task<InventoryItem> CreateItemAsync(InventoryItem item)
+        public async Task<InventoryItem> CreateItemAsync(Guid projectId, InventoryItem item)
         {
             if (await _db.InventoryItems.AnyAsync(i =>
                     i.Title == item.Title ||
@@ -26,12 +28,13 @@ namespace SFServer.API.Services
                 return null;
             }
 
+            item.ProjectId = projectId;
             _db.InventoryItems.Add(item);
             await _db.SaveChangesAsync();
             return item;
         }
 
-        public async Task<bool> UpdateItemAsync(InventoryItem item)
+        public async Task<bool> UpdateItemAsync(Guid projectId, InventoryItem item)
         {
             if (await _db.InventoryItems.AnyAsync(i =>
                     i.Id != item.Id &&
@@ -41,14 +44,18 @@ namespace SFServer.API.Services
                 return false;
             }
 
-            _db.InventoryItems.Update(item);
+            var existing = await _db.InventoryItems.FirstOrDefaultAsync(i => i.Id == item.Id && i.ProjectId == projectId);
+            if (existing == null)
+                return false;
+
+            _db.Entry(existing).CurrentValues.SetValues(item);
             await _db.SaveChangesAsync();
             return true;
         }
 
-        public async Task DeleteItemAsync(Guid id)
+        public async Task DeleteItemAsync(Guid projectId, Guid id)
         {
-            var existing = await _db.InventoryItems.FindAsync(id);
+            var existing = await _db.InventoryItems.FirstOrDefaultAsync(i => i.Id == id && i.ProjectId == projectId);
             if (existing != null)
             {
                 _db.InventoryItems.Remove(existing);
@@ -56,12 +63,12 @@ namespace SFServer.API.Services
             }
         }
 
-        public Task<List<PlayerInventoryItem>> GetPlayerInventoryAsync(Guid playerId)
-            => _db.PlayerInventoryItems.Where(p => p.UserId == playerId).ToListAsync();
+        public Task<List<PlayerInventoryItem>> GetPlayerInventoryAsync(Guid projectId, Guid playerId)
+            => _db.PlayerInventoryItems.Where(p => p.UserId == playerId && p.ProjectId == projectId).ToListAsync();
 
-        public async Task UpdatePlayerInventoryAsync(Guid playerId, List<PlayerInventoryItem> items)
+        public async Task UpdatePlayerInventoryAsync(Guid projectId, Guid playerId, List<PlayerInventoryItem> items)
         {
-            var existing = _db.PlayerInventoryItems.Where(p => p.UserId == playerId);
+            var existing = _db.PlayerInventoryItems.Where(p => p.UserId == playerId && p.ProjectId == projectId);
             _db.PlayerInventoryItems.RemoveRange(existing);
 
             var grouped = items
@@ -70,7 +77,8 @@ namespace SFServer.API.Services
                 .Select(g => new PlayerInventoryItem
                 {
                     ItemId = g.Key,
-                    Amount = g.Sum(x => x.Amount)
+                    Amount = g.Sum(x => x.Amount),
+                    ProjectId = projectId
                 });
 
             foreach (var item in grouped)

--- a/SFServer.API/Services/InventoryService.cs
+++ b/SFServer.API/Services/InventoryService.cs
@@ -64,11 +64,11 @@ namespace SFServer.API.Services
         }
 
         public Task<List<PlayerInventoryItem>> GetPlayerInventoryAsync(Guid projectId, Guid playerId)
-            => _db.PlayerInventoryItems.Where(p => p.UserId == playerId && p.ProjectId == projectId).ToListAsync();
+            => _db.PlayerInventoryItems.Where(p => p.UserId == playerId).ToListAsync();
 
         public async Task UpdatePlayerInventoryAsync(Guid projectId, Guid playerId, List<PlayerInventoryItem> items)
         {
-            var existing = _db.PlayerInventoryItems.Where(p => p.UserId == playerId && p.ProjectId == projectId);
+            var existing = _db.PlayerInventoryItems.Where(p => p.UserId == playerId);
             _db.PlayerInventoryItems.RemoveRange(existing);
 
             var grouped = items
@@ -77,8 +77,7 @@ namespace SFServer.API.Services
                 .Select(g => new PlayerInventoryItem
                 {
                     ItemId = g.Key,
-                    Amount = g.Sum(x => x.Amount),
-                    ProjectId = projectId
+                    Amount = g.Sum(x => x.Amount)
                 });
 
             foreach (var item in grouped)

--- a/SFServer.API/Services/InventoryService.cs
+++ b/SFServer.API/Services/InventoryService.cs
@@ -82,7 +82,7 @@ namespace SFServer.API.Services
 
             foreach (var item in grouped)
             {
-                item.Id = Guid.NewGuid();
+                item.Id = Guid.CreateVersion7();
                 item.UserId = playerId;
                 _db.PlayerInventoryItems.Add(item);
             }

--- a/SFServer.API/Utils/AuditLogMiddleware.cs
+++ b/SFServer.API/Utils/AuditLogMiddleware.cs
@@ -32,9 +32,17 @@ namespace SFServer.API.Utils
             
             Console.WriteLine("User Id: " + userIdString);
 
+            Guid projectId = Guid.Empty;
+            var segments = context.Request.Path.Value?.Split('/', StringSplitOptions.RemoveEmptyEntries);
+            if (segments != null && segments.Length > 0)
+            {
+                Guid.TryParse(segments[0], out projectId);
+            }
+
             var entry = new AuditLogEntry
             {
                 Id = Guid.CreateVersion7(),
+                ProjectId = projectId,
                 UserId = Guid.TryParse(userIdString, out var g) ? g : null,
                 Path = context.Request.Path,
                 Method = context.Request.Method,

--- a/SFServer.API/Utils/AuditLogMiddleware.cs
+++ b/SFServer.API/Utils/AuditLogMiddleware.cs
@@ -30,8 +30,6 @@ namespace SFServer.API.Utils
                 userIdString = context.User?.FindFirstValue("UserId");
             }
             
-            Console.WriteLine("User Id: " + userIdString);
-
             Guid projectId = Guid.Empty;
             var segments = context.Request.Path.Value?.Split('/', StringSplitOptions.RemoveEmptyEntries);
             if (segments != null && segments.Length > 0)

--- a/SFServer.Shared/SFServer.Shared.csproj
+++ b/SFServer.Shared/SFServer.Shared.csproj
@@ -14,6 +14,7 @@
 
     <ItemGroup>
       <PackageReference Include="JetBrains.Annotations" Version="2024.3.0" />
+      <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
       <PackageReference Include="MemoryPack" Version="1.21.4" />
       <PackageReference Include="MemoryPack.UnityShims" Version="1.21.4" />
     </ItemGroup>

--- a/SFServer.Shared/Server/Admin/Administrator.cs
+++ b/SFServer.Shared/Server/Admin/Administrator.cs
@@ -1,0 +1,14 @@
+using System;
+using MemoryPack;
+
+namespace SFServer.Shared.Server.Admin;
+
+[MemoryPackable]
+public partial class Administrator
+{
+    public Guid Id { get; set; }
+    public string Username { get; set; }
+    public string Email { get; set; }
+    public string PasswordHash { get; set; }
+    public DateTime CreatedAt { get; set; }
+}

--- a/SFServer.Shared/Server/Admin/CreateAdminRequest.cs
+++ b/SFServer.Shared/Server/Admin/CreateAdminRequest.cs
@@ -1,0 +1,17 @@
+using MemoryPack;
+using System.ComponentModel.DataAnnotations;
+
+namespace SFServer.Shared.Server.Admin;
+
+[MemoryPackable]
+public partial class CreateAdminRequest
+{
+    [Required]
+    public string Username { get; set; }
+
+    [EmailAddress]
+    public string Email { get; set; }
+
+    [Required]
+    public string Password { get; set; }
+}

--- a/SFServer.Shared/Server/Audit/AuditLogEntry.cs
+++ b/SFServer.Shared/Server/Audit/AuditLogEntry.cs
@@ -7,6 +7,7 @@ namespace SFServer.Shared.Server.Audit
     public partial class AuditLogEntry
     {
         public Guid Id { get; set; }
+        public Guid ProjectId { get; set; }
         public Guid? UserId { get; set; }
         public string Path { get; set; }
         public string Method { get; set; }

--- a/SFServer.Shared/Server/Inventory/InventoryItem.cs
+++ b/SFServer.Shared/Server/Inventory/InventoryItem.cs
@@ -8,6 +8,7 @@ namespace SFServer.Shared.Server.Inventory
     public partial class InventoryItem
     {
         public Guid Id { get; set; }
+        public Guid ProjectId { get; set; }
         public string Title { get; set; }
         public InventoryItemType Type { get; set; }
         public InventoryItemRarity Rarity { get; set; }

--- a/SFServer.Shared/Server/Inventory/PlayerInventoryItem.cs
+++ b/SFServer.Shared/Server/Inventory/PlayerInventoryItem.cs
@@ -7,6 +7,7 @@ namespace SFServer.Shared.Server.Inventory
     public partial class PlayerInventoryItem
     {
         public Guid Id { get; set; }
+        public Guid ProjectId { get; set; }
         public Guid UserId { get; set; }
         public Guid ItemId { get; set; }
         public int Amount { get; set; }

--- a/SFServer.Shared/Server/Inventory/PlayerInventoryItem.cs
+++ b/SFServer.Shared/Server/Inventory/PlayerInventoryItem.cs
@@ -7,7 +7,6 @@ namespace SFServer.Shared.Server.Inventory
     public partial class PlayerInventoryItem
     {
         public Guid Id { get; set; }
-        public Guid ProjectId { get; set; }
         public Guid UserId { get; set; }
         public Guid ItemId { get; set; }
         public int Amount { get; set; }

--- a/SFServer.Shared/Server/Project/ProjectInfo.cs
+++ b/SFServer.Shared/Server/Project/ProjectInfo.cs
@@ -1,0 +1,11 @@
+using System;
+using MemoryPack;
+
+namespace SFServer.Shared.Server.Project;
+
+[MemoryPackable]
+public partial class ProjectInfo
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+}

--- a/SFServer.Shared/Server/Settings/GlobalSettings.cs
+++ b/SFServer.Shared/Server/Settings/GlobalSettings.cs
@@ -9,9 +9,5 @@ namespace SFServer.Shared.Server.Settings
         public Guid Id { get; set; }
         public string ServerTitle { get; set; } = string.Empty;
         public string ServerCopyright { get; set; } = string.Empty;
-        public string GoogleClientId { get; set; } = string.Empty;
-        public string ClickHouseConnection { get; set; } = string.Empty;
-        public string GoogleClientSecret { get; set; } = string.Empty;
-        public string GoogleServiceAccountJson { get; set; } = string.Empty;
     }
 }

--- a/SFServer.Shared/Server/Settings/GlobalSettings.cs
+++ b/SFServer.Shared/Server/Settings/GlobalSettings.cs
@@ -4,10 +4,9 @@ using MemoryPack;
 namespace SFServer.Shared.Server.Settings
 {
     [MemoryPackable]
-    public partial class ServerSettings
+    public partial class GlobalSettings
     {
         public Guid Id { get; set; }
-        public Guid ProjectId { get; set; }
         public string ServerTitle { get; set; } = string.Empty;
         public string ServerCopyright { get; set; } = string.Empty;
         public string GoogleClientId { get; set; } = string.Empty;

--- a/SFServer.Shared/Server/Settings/ProjectSettings.cs
+++ b/SFServer.Shared/Server/Settings/ProjectSettings.cs
@@ -1,0 +1,18 @@
+using System;
+using MemoryPack;
+
+namespace SFServer.Shared.Server.Settings
+{
+    [MemoryPackable]
+    public partial class ProjectSettings
+    {
+        public Guid Id { get; set; }
+        public Guid ProjectId { get; set; }
+        public string ServerTitle { get; set; } = string.Empty;
+        public string ServerCopyright { get; set; } = string.Empty;
+        public string GoogleClientId { get; set; } = string.Empty;
+        public string ClickHouseConnection { get; set; } = string.Empty;
+        public string GoogleClientSecret { get; set; } = string.Empty;
+        public string GoogleServiceAccountJson { get; set; } = string.Empty;
+    }
+}

--- a/SFServer.Shared/Server/Settings/ProjectSettings.cs
+++ b/SFServer.Shared/Server/Settings/ProjectSettings.cs
@@ -14,5 +14,6 @@ namespace SFServer.Shared.Server.Settings
         public string ClickHouseConnection { get; set; } = string.Empty;
         public string GoogleClientSecret { get; set; } = string.Empty;
         public string GoogleServiceAccountJson { get; set; } = string.Empty;
+        public string BundleId { get; set; } = string.Empty;
     }
 }

--- a/SFServer.Shared/Server/Settings/ServerSettings.cs
+++ b/SFServer.Shared/Server/Settings/ServerSettings.cs
@@ -7,6 +7,7 @@ namespace SFServer.Shared.Server.Settings
     public partial class ServerSettings
     {
         public Guid Id { get; set; }
+        public Guid ProjectId { get; set; }
         public string ServerTitle { get; set; } = string.Empty;
         public string ServerCopyright { get; set; } = string.Empty;
         public string GoogleClientId { get; set; } = string.Empty;

--- a/SFServer.Shared/Server/UserProfile/UserDevice.cs
+++ b/SFServer.Shared/Server/UserProfile/UserDevice.cs
@@ -8,6 +8,7 @@ namespace SFServer.Shared.Server.UserProfile
     public partial class UserDevice
     {
         public Guid Id { get; set; }
+        public Guid ProjectId { get; set; }
         public Guid UserId { get; set; }
         public string DeviceId { get; set; }
         public string DeviceModel { get; set; }

--- a/SFServer.Shared/Server/UserProfile/UserDevice.cs
+++ b/SFServer.Shared/Server/UserProfile/UserDevice.cs
@@ -8,7 +8,6 @@ namespace SFServer.Shared.Server.UserProfile
     public partial class UserDevice
     {
         public Guid Id { get; set; }
-        public Guid ProjectId { get; set; }
         public Guid UserId { get; set; }
         public string DeviceId { get; set; }
         public string DeviceModel { get; set; }

--- a/SFServer.Shared/Server/UserProfile/UserProfile.cs
+++ b/SFServer.Shared/Server/UserProfile/UserProfile.cs
@@ -21,7 +21,6 @@ namespace SFServer.Shared.Server.UserProfile
         public DateTime LastEditAt { get; set; }
         public DateTime LastLoginAt { get; set; }
         public UserRole Role { get; set; }
-        public string PasswordHash { get; set; }
         public string GooglePlayId { get; set; }
         public bool DebugMode { get; set; }
         public List<string> DeviceIds { get; set; } = new();

--- a/SFServer.Shared/Server/UserProfile/UserProfile.cs
+++ b/SFServer.Shared/Server/UserProfile/UserProfile.cs
@@ -10,6 +10,7 @@ namespace SFServer.Shared.Server.UserProfile
     {
         public Guid Id { get; set; }
         public int Index { get; private set; }
+        public Guid ProjectId { get; set; }
         public string Username { get; set; }
         public string FullName { get; set; }
         public int? Age { get; set; }

--- a/SFServer.Shared/Server/Wallet/Currency.cs
+++ b/SFServer.Shared/Server/Wallet/Currency.cs
@@ -7,6 +7,7 @@ namespace SFServer.Shared.Server.Wallet
     public partial class Currency
     {
         public Guid Id { get; set; }
+        public Guid ProjectId { get; set; }
 
         public string Title { get; set; }
         

--- a/SFServer.Shared/Server/Wallet/WalletItem.cs
+++ b/SFServer.Shared/Server/Wallet/WalletItem.cs
@@ -7,7 +7,6 @@ namespace SFServer.Shared.Server.Wallet
     public partial class WalletItem
     {
         public Guid Id { get; set; }
-        public Guid ProjectId { get; set; }
 
         // Foreign key to user
         public Guid UserId { get; set; }

--- a/SFServer.Shared/Server/Wallet/WalletItem.cs
+++ b/SFServer.Shared/Server/Wallet/WalletItem.cs
@@ -7,6 +7,7 @@ namespace SFServer.Shared.Server.Wallet
     public partial class WalletItem
     {
         public Guid Id { get; set; }
+        public Guid ProjectId { get; set; }
 
         // Foreign key to user
         public Guid UserId { get; set; }

--- a/SFServer.UI/Controllers/AdministratorsController.cs
+++ b/SFServer.UI/Controllers/AdministratorsController.cs
@@ -1,0 +1,46 @@
+using System.Net.Http;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
+using SFServer.Shared.Server.Admin;
+
+namespace SFServer.UI.Controllers;
+
+[Authorize(Roles = "Admin")]
+public class AdministratorsController : Controller
+{
+    private readonly IConfiguration _config;
+
+    public AdministratorsController(IConfiguration config)
+    {
+        _config = config;
+    }
+
+    private HttpClient GetClient() => User.CreateApiClient(_config);
+
+    public async Task<IActionResult> Index()
+    {
+        using var client = GetClient();
+        var admins = await client.GetFromMessagePackAsync<List<Administrator>>("Administrators");
+        return View(admins);
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> Create(CreateAdminRequest model)
+    {
+        if (!ModelState.IsValid)
+            return RedirectToAction(nameof(Index));
+
+        using var client = GetClient();
+        await client.PostAsMessagePackAsync<CreateAdminRequest, Administrator>("Administrators", model);
+        return RedirectToAction(nameof(Index));
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> Delete(Guid id)
+    {
+        using var client = GetClient();
+        await client.DeleteAsync($"Administrators/{id}");
+        return RedirectToAction(nameof(Index));
+    }
+}

--- a/SFServer.UI/Controllers/AdministratorsController.cs
+++ b/SFServer.UI/Controllers/AdministratorsController.cs
@@ -10,10 +10,12 @@ namespace SFServer.UI.Controllers;
 public class AdministratorsController : Controller
 {
     private readonly IConfiguration _config;
+    private readonly ProjectContext _project;
 
-    public AdministratorsController(IConfiguration config)
+    public AdministratorsController(IConfiguration config, ProjectContext project)
     {
         _config = config;
+        _project = project;
     }
 
     private HttpClient GetClient() => User.CreateApiClient(_config);
@@ -29,11 +31,11 @@ public class AdministratorsController : Controller
     public async Task<IActionResult> Create(CreateAdminRequest model)
     {
         if (!ModelState.IsValid)
-            return RedirectToAction(nameof(Index));
+            return RedirectToAction(nameof(Index), new { projectId = _project.CurrentProjectId });
 
         using var client = GetClient();
         await client.PostAsMessagePackAsync<CreateAdminRequest, Administrator>("Administrators", model);
-        return RedirectToAction(nameof(Index));
+        return RedirectToAction(nameof(Index), new { projectId = _project.CurrentProjectId });
     }
 
     [HttpPost]
@@ -41,6 +43,6 @@ public class AdministratorsController : Controller
     {
         using var client = GetClient();
         await client.DeleteAsync($"Administrators/{id}");
-        return RedirectToAction(nameof(Index));
+        return RedirectToAction(nameof(Index), new { projectId = _project.CurrentProjectId });
     }
 }

--- a/SFServer.UI/Controllers/AuditLogController.cs
+++ b/SFServer.UI/Controllers/AuditLogController.cs
@@ -81,7 +81,7 @@ namespace SFServer.UI.Controllers
                 TempData["Success"] = "Audit log cleared.";
             else
                 TempData["Error"] = "Failed to clear audit log.";
-            return RedirectToAction("Index");
+            return RedirectToAction("Index", new { projectId = _project.CurrentProjectId });
         }
 
         public async Task<IActionResult> Export()
@@ -91,7 +91,7 @@ namespace SFServer.UI.Controllers
             if (!response.IsSuccessStatusCode)
             {
                 TempData["Error"] = "Failed to export audit log.";
-                return RedirectToAction("Index");
+                return RedirectToAction("Index", new { projectId = _project.CurrentProjectId });
             }
 
             var fileBytes = await response.Content.ReadAsByteArrayAsync();

--- a/SFServer.UI/Controllers/AuditLogController.cs
+++ b/SFServer.UI/Controllers/AuditLogController.cs
@@ -17,15 +17,17 @@ namespace SFServer.UI.Controllers
     public class AuditLogController : Controller
     {
         private readonly IConfiguration _config;
+        private readonly ProjectContext _project;
 
-        public AuditLogController(IConfiguration config)
+        public AuditLogController(IConfiguration config, ProjectContext project)
         {
             _config = config;
+            _project = project;
         }
 
         private HttpClient GetClient()
         {
-            return User.CreateApiClient(_config);
+            return User.CreateApiClient(_config, _project.CurrentProjectId);
         }
 
         public async Task<IActionResult> Index()

--- a/SFServer.UI/Controllers/AuditLogController.cs
+++ b/SFServer.UI/Controllers/AuditLogController.cs
@@ -34,8 +34,8 @@ namespace SFServer.UI.Controllers
         {
             using var client = GetClient();
 
-            var logs = await client.GetFromMessagePackAsync<List<AuditLogEntry>>("AuditLog?count=100");
-            var profiles = await client.GetFromMessagePackAsync<List<UserProfile>>("UserProfiles");
+            var logs = await client.GetFromMessagePackAsync<List<AuditLogEntry>>("AuditLog?count=100") ?? new();
+            var profiles = await client.GetFromMessagePackAsync<List<UserProfile>>("UserProfiles") ?? new();
             var profileLookup = profiles.ToDictionary(p => p.Id);
 
             var groups = new Dictionary<UserRole, List<AuditLogEntry>>();

--- a/SFServer.UI/Controllers/EconomyController.cs
+++ b/SFServer.UI/Controllers/EconomyController.cs
@@ -14,15 +14,17 @@ namespace SFServer.UI.Controllers
     public class EconomyController : Controller
     {
         private readonly IConfiguration _configuration;
+        private readonly ProjectContext _project;
 
-        public EconomyController(IConfiguration configuration)
+        public EconomyController(IConfiguration configuration, ProjectContext project)
         {
             _configuration = configuration;
+            _project = project;
         }
 
         private HttpClient GetAuthenticatedHttpClient()
         {
-            return User.CreateApiClient(_configuration);
+            return User.CreateApiClient(_configuration, _project.CurrentProjectId);
         }
 
         // GET: /Economy/Index

--- a/SFServer.UI/Controllers/EconomyController.cs
+++ b/SFServer.UI/Controllers/EconomyController.cs
@@ -67,7 +67,7 @@ namespace SFServer.UI.Controllers
                 TempData["Error"] = $"Failed to add currency: {response.StatusCode}";
             }
 
-            return RedirectToAction("Index");
+            return RedirectToAction("Index", new { projectId = _project.CurrentProjectId });
         }
 
         // GET: /Economy/EditCurrency/{id}
@@ -87,7 +87,7 @@ namespace SFServer.UI.Controllers
             catch (ApiRequestException ex)
             {
                 TempData["Error"] = $"Failed to load currency: {ex.Message}";
-                return RedirectToAction("Index");
+                return RedirectToAction("Index", new { projectId = _project.CurrentProjectId });
             }
 
             if (currency == null)
@@ -133,7 +133,7 @@ namespace SFServer.UI.Controllers
             var response = await httpClient.PutAsMessagePackAsync($"Currency/{model.Id}", updatedCurrency);
             if (response.IsSuccessStatusCode)
             {
-                return RedirectToAction("Index", "Economy");
+                return RedirectToAction("Index", "Economy", new { projectId = _project.CurrentProjectId });
             }
             else
             {
@@ -154,7 +154,7 @@ namespace SFServer.UI.Controllers
                 TempData["Error"] = "Failed to delete currency.";
             }
 
-            return RedirectToAction("Index");
+            return RedirectToAction("Index", new { projectId = _project.CurrentProjectId });
         }
     }
 }

--- a/SFServer.UI/Controllers/GlobalSettingsController.cs
+++ b/SFServer.UI/Controllers/GlobalSettingsController.cs
@@ -1,0 +1,107 @@
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
+using SFServer.Shared.Server.Settings;
+using SFServer.Shared.Server.Admin;
+using SFServer.Shared.Server.Project;
+using SFServer.UI.Models;
+
+namespace SFServer.UI.Controllers
+{
+    [Authorize(Roles = "Admin")]
+    public class GlobalSettingsController : Controller
+    {
+        private readonly IConfiguration _configuration;
+        private readonly GlobalSettingsService _service;
+
+        public GlobalSettingsController(IConfiguration configuration, GlobalSettingsService service)
+        {
+            _configuration = configuration;
+            _service = service;
+        }
+
+        private HttpClient GetClient() => User.CreateApiClient(_configuration);
+
+        public async Task<IActionResult> Index()
+        {
+            using var client = GetClient();
+            var settings = await client.GetFromMessagePackAsync<GlobalSettings>("GlobalSettings") ?? new GlobalSettings();
+            _service.UpdateCache(settings);
+
+            var admins = await client.GetFromMessagePackAsync<List<Administrator>>("Administrators");
+            var projects = await client.GetFromMessagePackAsync<List<ProjectInfo>>("Projects");
+
+            var model = new GlobalSettingsViewModel
+            {
+                Settings = settings,
+                Administrators = admins ?? new(),
+                Projects = projects ?? new()
+            };
+            return View(model);
+        }
+
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> Save(GlobalSettings settings)
+        {
+            if (!ModelState.IsValid)
+                return RedirectToAction(nameof(Index));
+
+            using var client = GetClient();
+            var response = await client.PutAsMessagePackAsync("GlobalSettings", settings);
+            if (response.IsSuccessStatusCode)
+            {
+                TempData["Success"] = "Settings saved.";
+                _service.UpdateCache(settings);
+            }
+            else
+            {
+                TempData["Error"] = "Failed to save settings.";
+            }
+            return RedirectToAction(nameof(Index));
+        }
+
+        [HttpPost]
+        public async Task<IActionResult> AddAdmin(CreateAdminRequest request)
+        {
+            using var client = GetClient();
+            await client.PostAsMessagePackAsync<CreateAdminRequest, Administrator>("Administrators", request);
+            return RedirectToAction(nameof(Index));
+        }
+
+        [HttpPost]
+        public async Task<IActionResult> DeleteAdmin(Guid id)
+        {
+            using var client = GetClient();
+            await client.DeleteAsync($"Administrators/{id}");
+            return RedirectToAction(nameof(Index));
+        }
+
+        [HttpPost]
+        public async Task<IActionResult> CreateProject(string name)
+        {
+            using var client = GetClient();
+            await client.PostAsMessagePackAsync<ProjectInfo, ProjectInfo>("Projects", new ProjectInfo { Name = name });
+            return RedirectToAction(nameof(Index));
+        }
+
+        [HttpPost]
+        public async Task<IActionResult> RenameProject(Guid id, string name)
+        {
+            using var client = GetClient();
+            await client.PutAsMessagePackAsync($"Projects/{id}", new ProjectInfo { Id = id, Name = name });
+            return RedirectToAction(nameof(Index));
+        }
+
+        [HttpPost]
+        public async Task<IActionResult> DeleteProject(Guid id)
+        {
+            using var client = GetClient();
+            await client.DeleteAsync($"Projects/{id}");
+            return RedirectToAction(nameof(Index));
+        }
+    }
+}

--- a/SFServer.UI/Controllers/ProjectSettingsController.cs
+++ b/SFServer.UI/Controllers/ProjectSettingsController.cs
@@ -44,6 +44,7 @@ namespace SFServer.UI.Controllers
                 ClickHouseConnection = settings.ClickHouseConnection,
                 GoogleClientSecret = settings.GoogleClientSecret,
                 GoogleServiceAccountJson = settings.GoogleServiceAccountJson
+                ,BundleId = settings.BundleId
             };
             return View(vm);
         }
@@ -63,6 +64,7 @@ namespace SFServer.UI.Controllers
                 GoogleClientSecret = model.GoogleClientSecret,
                 ClickHouseConnection = model.ClickHouseConnection,
                 GoogleServiceAccountJson = model.GoogleServiceAccountJson,
+                BundleId = model.BundleId
             };
             var response = await client.PutAsMessagePackAsync("ProjectSettings", payload);
             if (!response.IsSuccessStatusCode)

--- a/SFServer.UI/Controllers/ProjectSettingsController.cs
+++ b/SFServer.UI/Controllers/ProjectSettingsController.cs
@@ -12,12 +12,12 @@ using SFServer.UI;
 namespace SFServer.UI.Controllers
 {
     [Authorize(Roles = "Admin")]
-    public class ServerSettingsController : Controller
+    public class ProjectSettingsController : Controller
     {
         private readonly IConfiguration _configuration;
-        private readonly ServerSettingsService _service;
+        private readonly ProjectSettingsService _service;
         private readonly ProjectContext _project;
-        public ServerSettingsController(IConfiguration configuration, ServerSettingsService service, ProjectContext project)
+        public ProjectSettingsController(IConfiguration configuration, ProjectSettingsService service, ProjectContext project)
         {
             _configuration = configuration;
             _service = service;
@@ -32,12 +32,12 @@ namespace SFServer.UI.Controllers
         public async Task<IActionResult> Index()
         {
             using var client = GetAuthenticatedHttpClient();
-            var settings = await client.GetFromMessagePackAsync<ServerSettings>("ServerSettings");
+            var settings = await client.GetFromMessagePackAsync<ProjectSettings>("ProjectSettings");
             if (settings != null)
                 _service.UpdateCache(settings);
             else
-                settings = new ServerSettings();
-            var vm = new ServerSettingsViewModel
+                settings = new ProjectSettings();
+            var vm = new ProjectSettingsViewModel
             {
                 Id = settings.Id,
                 ServerTitle = settings.ServerTitle,
@@ -52,13 +52,13 @@ namespace SFServer.UI.Controllers
 
         [HttpPost]
         [ValidateAntiForgeryToken]
-        public async Task<IActionResult> Index(ServerSettingsViewModel model)
+        public async Task<IActionResult> Index(ProjectSettingsViewModel model)
         {
             if (!ModelState.IsValid)
                 return View(model);
 
             using var client = GetAuthenticatedHttpClient();
-            var payload = new ServerSettings
+            var payload = new ProjectSettings
             {
                 Id = model.Id,
                 ServerTitle = model.ServerTitle,
@@ -68,7 +68,7 @@ namespace SFServer.UI.Controllers
                 ClickHouseConnection = model.ClickHouseConnection,
                 GoogleServiceAccountJson = model.GoogleServiceAccountJson,
             };
-            var response = await client.PutAsMessagePackAsync("ServerSettings", payload);
+            var response = await client.PutAsMessagePackAsync("ProjectSettings", payload);
             if (!response.IsSuccessStatusCode)
             {
                 TempData["Error"] = "Failed to save settings.";

--- a/SFServer.UI/Controllers/ProjectSettingsController.cs
+++ b/SFServer.UI/Controllers/ProjectSettingsController.cs
@@ -40,8 +40,6 @@ namespace SFServer.UI.Controllers
             var vm = new ProjectSettingsViewModel
             {
                 Id = settings.Id,
-                ServerTitle = settings.ServerTitle,
-                ServerCopyright = settings.ServerCopyright,
                 GoogleClientId = settings.GoogleClientId,
                 ClickHouseConnection = settings.ClickHouseConnection,
                 GoogleClientSecret = settings.GoogleClientSecret,
@@ -61,8 +59,6 @@ namespace SFServer.UI.Controllers
             var payload = new ProjectSettings
             {
                 Id = model.Id,
-                ServerTitle = model.ServerTitle,
-                ServerCopyright = model.ServerCopyright,
                 GoogleClientId = model.GoogleClientId,
                 GoogleClientSecret = model.GoogleClientSecret,
                 ClickHouseConnection = model.ClickHouseConnection,

--- a/SFServer.UI/Controllers/ProjectsController.cs
+++ b/SFServer.UI/Controllers/ProjectsController.cs
@@ -34,6 +34,8 @@ public class ProjectsController : Controller
         using var client = GetClient();
         var list = await client.GetFromMessagePackAsync<List<ProjectInfo>>("Projects");
         var proj = list.FirstOrDefault(p => p.Id == id);
+        if (proj == null && list.Count > 0)
+            proj = list.First();
         if (proj != null)
         {
             _context.CurrentProjectId = proj.Id;
@@ -77,8 +79,18 @@ public class ProjectsController : Controller
         await client.DeleteAsync($"Projects/{id}");
         if (_context.CurrentProjectId == id)
         {
-            _context.CurrentProjectId = Guid.Empty;
-            _context.CurrentProjectName = string.Empty;
+            var list = await client.GetFromMessagePackAsync<List<ProjectInfo>>("Projects") ?? new();
+            var proj = list.FirstOrDefault();
+            if (proj != null)
+            {
+                _context.CurrentProjectId = proj.Id;
+                _context.CurrentProjectName = proj.Name;
+            }
+            else
+            {
+                _context.CurrentProjectId = Guid.Empty;
+                _context.CurrentProjectName = string.Empty;
+            }
         }
         return RedirectToAction(nameof(Index), new { projectId = _context.CurrentProjectId });
     }
@@ -90,6 +102,8 @@ public class ProjectsController : Controller
         using var client = GetClient();
         var list = await client.GetFromMessagePackAsync<List<ProjectInfo>>("Projects");
         var proj = list.FirstOrDefault(p => p.Id == id);
+        if (proj == null && list.Count > 0)
+            proj = list.First();
         if (proj != null)
         {
             _context.CurrentProjectId = proj.Id;

--- a/SFServer.UI/Controllers/ProjectsController.cs
+++ b/SFServer.UI/Controllers/ProjectsController.cs
@@ -54,8 +54,25 @@ public class ProjectsController : Controller
 
     [HttpPost]
     [Authorize(Roles = "Admin")]
+    public async Task<IActionResult> Rename(Guid id, string name)
+    {
+        using var client = GetClient();
+        var project = new ProjectInfo { Id = id, Name = name };
+        await client.PutAsMessagePackAsync($"Projects/{id}", project);
+        if (_context.CurrentProjectId == id)
+        {
+            _context.CurrentProjectName = name;
+        }
+        return RedirectToAction(nameof(Index));
+    }
+
+    [HttpPost]
+    [Authorize(Roles = "Admin")]
     public async Task<IActionResult> Delete(Guid id)
     {
+        if (id == Guid.Empty)
+            return RedirectToAction(nameof(Index));
+
         using var client = GetClient();
         await client.DeleteAsync($"Projects/{id}");
         if (_context.CurrentProjectId == id)

--- a/SFServer.UI/Controllers/ProjectsController.cs
+++ b/SFServer.UI/Controllers/ProjectsController.cs
@@ -95,6 +95,6 @@ public class ProjectsController : Controller
             _context.CurrentProjectId = proj.Id;
             _context.CurrentProjectName = proj.Name;
         }
-        return RedirectToAction("Index", "ServerSettings", new { projectId = _context.CurrentProjectId });
+        return RedirectToAction("Index", "ProjectSettings", new { projectId = _context.CurrentProjectId });
     }
 }

--- a/SFServer.UI/Controllers/ProjectsController.cs
+++ b/SFServer.UI/Controllers/ProjectsController.cs
@@ -1,0 +1,68 @@
+using System.Net.Http;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
+using SFServer.Shared.Server.Project;
+using SFServer.UI;
+
+namespace SFServer.UI.Controllers;
+
+[Authorize]
+public class ProjectsController : Controller
+{
+    private readonly IConfiguration _config;
+    private readonly ProjectContext _context;
+
+    public ProjectsController(IConfiguration config, ProjectContext context)
+    {
+        _config = config;
+        _context = context;
+    }
+
+    private HttpClient GetClient(Guid projectId = default) => User.CreateApiClient(_config, projectId);
+
+    public async Task<IActionResult> Index()
+    {
+        using var client = GetClient();
+        var projects = await client.GetFromMessagePackAsync<List<ProjectInfo>>("Projects");
+        return View(projects);
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> Select(Guid id)
+    {
+        using var client = GetClient();
+        var list = await client.GetFromMessagePackAsync<List<ProjectInfo>>("Projects");
+        var proj = list.FirstOrDefault(p => p.Id == id);
+        if (proj != null)
+        {
+            _context.CurrentProjectId = proj.Id;
+            _context.CurrentProjectName = proj.Name;
+        }
+        return RedirectToAction("Index", "Home");
+    }
+
+    [HttpPost]
+    [Authorize(Roles = "Admin")]
+    public async Task<IActionResult> Create(string name)
+    {
+        using var client = GetClient();
+        var project = new ProjectInfo { Name = name };
+        await client.PostAsMessagePackAsync<ProjectInfo, ProjectInfo>("Projects", project);
+        return RedirectToAction(nameof(Index));
+    }
+
+    [HttpPost]
+    [Authorize(Roles = "Admin")]
+    public async Task<IActionResult> Delete(Guid id)
+    {
+        using var client = GetClient();
+        await client.DeleteAsync($"Projects/{id}");
+        if (_context.CurrentProjectId == id)
+        {
+            _context.CurrentProjectId = Guid.Empty;
+            _context.CurrentProjectName = string.Empty;
+        }
+        return RedirectToAction(nameof(Index));
+    }
+}

--- a/SFServer.UI/Controllers/ProjectsController.cs
+++ b/SFServer.UI/Controllers/ProjectsController.cs
@@ -82,4 +82,19 @@ public class ProjectsController : Controller
         }
         return RedirectToAction(nameof(Index));
     }
+
+    [HttpPost]
+    [Authorize(Roles = "Admin")]
+    public async Task<IActionResult> Settings(Guid id)
+    {
+        using var client = GetClient();
+        var list = await client.GetFromMessagePackAsync<List<ProjectInfo>>("Projects");
+        var proj = list.FirstOrDefault(p => p.Id == id);
+        if (proj != null)
+        {
+            _context.CurrentProjectId = proj.Id;
+            _context.CurrentProjectName = proj.Name;
+        }
+        return RedirectToAction("Index", "ServerSettings");
+    }
 }

--- a/SFServer.UI/Controllers/ProjectsController.cs
+++ b/SFServer.UI/Controllers/ProjectsController.cs
@@ -39,7 +39,7 @@ public class ProjectsController : Controller
             _context.CurrentProjectId = proj.Id;
             _context.CurrentProjectName = proj.Name;
         }
-        return RedirectToAction("Index", "Home");
+        return RedirectToAction("Index", "Home", new { projectId = _context.CurrentProjectId });
     }
 
     [HttpPost]
@@ -49,7 +49,7 @@ public class ProjectsController : Controller
         using var client = GetClient();
         var project = new ProjectInfo { Name = name };
         await client.PostAsMessagePackAsync<ProjectInfo, ProjectInfo>("Projects", project);
-        return RedirectToAction(nameof(Index));
+        return RedirectToAction(nameof(Index), new { projectId = _context.CurrentProjectId });
     }
 
     [HttpPost]
@@ -63,7 +63,7 @@ public class ProjectsController : Controller
         {
             _context.CurrentProjectName = name;
         }
-        return RedirectToAction(nameof(Index));
+        return RedirectToAction(nameof(Index), new { projectId = _context.CurrentProjectId });
     }
 
     [HttpPost]
@@ -71,7 +71,7 @@ public class ProjectsController : Controller
     public async Task<IActionResult> Delete(Guid id)
     {
         if (id == Guid.Empty)
-            return RedirectToAction(nameof(Index));
+            return RedirectToAction(nameof(Index), new { projectId = _context.CurrentProjectId });
 
         using var client = GetClient();
         await client.DeleteAsync($"Projects/{id}");
@@ -80,7 +80,7 @@ public class ProjectsController : Controller
             _context.CurrentProjectId = Guid.Empty;
             _context.CurrentProjectName = string.Empty;
         }
-        return RedirectToAction(nameof(Index));
+        return RedirectToAction(nameof(Index), new { projectId = _context.CurrentProjectId });
     }
 
     [HttpPost]
@@ -95,6 +95,6 @@ public class ProjectsController : Controller
             _context.CurrentProjectId = proj.Id;
             _context.CurrentProjectName = proj.Name;
         }
-        return RedirectToAction("Index", "ServerSettings");
+        return RedirectToAction("Index", "ServerSettings", new { projectId = _context.CurrentProjectId });
     }
 }

--- a/SFServer.UI/Controllers/ServerSettingsController.cs
+++ b/SFServer.UI/Controllers/ServerSettingsController.cs
@@ -16,15 +16,17 @@ namespace SFServer.UI.Controllers
     {
         private readonly IConfiguration _configuration;
         private readonly ServerSettingsService _service;
-        public ServerSettingsController(IConfiguration configuration, ServerSettingsService service)
+        private readonly ProjectContext _project;
+        public ServerSettingsController(IConfiguration configuration, ServerSettingsService service, ProjectContext project)
         {
             _configuration = configuration;
             _service = service;
+            _project = project;
         }
 
         private HttpClient GetAuthenticatedHttpClient()
         {
-            return User.CreateApiClient(_configuration);
+            return User.CreateApiClient(_configuration, _project.CurrentProjectId);
         }
 
         public async Task<IActionResult> Index()

--- a/SFServer.UI/Controllers/ServerSettingsController.cs
+++ b/SFServer.UI/Controllers/ServerSettingsController.cs
@@ -78,7 +78,7 @@ namespace SFServer.UI.Controllers
                 TempData["Success"] = "Settings saved.";
                 _service.UpdateCache(payload);
             }
-            return RedirectToAction("Index");
+            return RedirectToAction("Index", new { projectId = _project.CurrentProjectId });
         }
     }
 }

--- a/SFServer.UI/Controllers/StatisticsController.cs
+++ b/SFServer.UI/Controllers/StatisticsController.cs
@@ -14,15 +14,17 @@ namespace SFServer.UI.Controllers
     public class StatisticsController : Controller
     {
         private readonly IConfiguration _configuration;
+        private readonly ProjectContext _project;
 
-        public StatisticsController(IConfiguration configuration)
+        public StatisticsController(IConfiguration configuration, ProjectContext project)
         {
             _configuration = configuration;
+            _project = project;
         }
 
         private HttpClient GetAuthenticatedHttpClient()
         {
-            return User.CreateApiClient(_configuration);
+            return User.CreateApiClient(_configuration, _project.CurrentProjectId);
         }
 
         public async Task<IActionResult> Index()

--- a/SFServer.UI/Controllers/UserProfilesController.cs
+++ b/SFServer.UI/Controllers/UserProfilesController.cs
@@ -43,6 +43,11 @@ namespace SFServer.UI.Controllers
 
                 // Retrieve profiles using MessagePack.
                 var profiles = await client.GetFromMessagePackAsync<List<UserProfile>>("UserProfiles");
+                if (profiles == null)
+                {
+                    TempData["Error"] = "Failed to load user profiles.";
+                    profiles = new List<UserProfile>();
+                }
 
                 // Filter profiles by search query.
                 if (!string.IsNullOrWhiteSpace(search))

--- a/SFServer.UI/Controllers/UserProfilesController.cs
+++ b/SFServer.UI/Controllers/UserProfilesController.cs
@@ -17,15 +17,17 @@ namespace SFServer.UI.Controllers
     public class UserProfilesController : Controller
     {
         private readonly IConfiguration _configuration;
+        private readonly ProjectContext _project;
 
-        public UserProfilesController(IConfiguration configuration)
+        public UserProfilesController(IConfiguration configuration, ProjectContext project)
         {
             _configuration = configuration;
+            _project = project;
         }
 
         private HttpClient GetAuthenticatedHttpClient()
         {
-            return User.CreateApiClient(_configuration);
+            return User.CreateApiClient(_configuration, _project.CurrentProjectId);
         }
 
         public async Task<IActionResult> Index(int page = 1, int pageSize = 20, string search = "", string sortColumn = "Id", string sortOrder = "asc")

--- a/SFServer.UI/Controllers/UserProfilesController.cs
+++ b/SFServer.UI/Controllers/UserProfilesController.cs
@@ -121,8 +121,6 @@ namespace SFServer.UI.Controllers
                 CreatedAt = DateTime.UtcNow
             };
 
-            var hasher = new PasswordHasher<UserProfile>();
-            newUser.PasswordHash = hasher.HashPassword(newUser, model.Password);
 
             using var client = GetAuthenticatedHttpClient();
 
@@ -268,12 +266,6 @@ namespace SFServer.UI.Controllers
             existingProfile.Role = model.Role;
             existingProfile.DebugMode = model.Role is UserRole.Admin or UserRole.Developer && model.DebugMode;
 
-            // Update password if provided.
-            if (!string.IsNullOrWhiteSpace(model.NewPassword) && model.NewPassword == model.ConfirmPassword)
-            {
-                var hasher = new PasswordHasher<UserProfile>();
-                existingProfile.PasswordHash = hasher.HashPassword(existingProfile, model.NewPassword);
-            }
 
             // Use MessagePack for PUT.
             var response = await httpClient.PutAsMessagePackAsync($"UserProfiles/{id}", existingProfile);

--- a/SFServer.UI/Controllers/UserProfilesController.cs
+++ b/SFServer.UI/Controllers/UserProfilesController.cs
@@ -199,7 +199,7 @@ namespace SFServer.UI.Controllers
                 viewModel.WalletItems = new List<WalletItemViewModel> { };
             }
 
-            var playerItems = await httpClient.GetFromMessagePackAsync<List<PlayerInventoryItem>>($"player/{profile.Id}/inventory");
+            var playerItems = await httpClient.GetFromMessagePackAsync<List<PlayerInventoryItem>>($"Inventory/player/{profile.Id}/inventory");
             var allItems = await httpClient.GetFromMessagePackAsync<List<InventoryItem>>("Inventory");
             if (playerItems != null && allItems != null)
             {
@@ -351,7 +351,7 @@ namespace SFServer.UI.Controllers
                 .Select(i => new PlayerInventoryItem { ItemId = i.ItemId!.Value, Amount = i.Amount })
                 .ToList();
 
-            await client.PutAsMessagePackAsync($"player/{model.UserId}/inventory", items);
+            await client.PutAsMessagePackAsync($"Inventory/player/{model.UserId}/inventory", items);
 
             TempData["Success"] = "Inventory updated successfully.";
             TempData["activeTab"] = "inventory";

--- a/SFServer.UI/Controllers/UserProfilesController.cs
+++ b/SFServer.UI/Controllers/UserProfilesController.cs
@@ -125,7 +125,7 @@ namespace SFServer.UI.Controllers
             var response = await client.PostMessagePackAsync("UserProfiles", newUser);
             if (response.IsSuccessStatusCode)
             {
-                return RedirectToAction("Index");
+                return RedirectToAction("Index", new { projectId = _project.CurrentProjectId });
             }
 
             var errorContent = await response.Content.ReadAsStringAsync();
@@ -149,7 +149,7 @@ namespace SFServer.UI.Controllers
             catch (ApiRequestException ex)
             {
                 TempData["Error"] = $"Failed to load user profile: {ex.Message}";
-                return RedirectToAction("Index");
+                return RedirectToAction("Index", new { projectId = _project.CurrentProjectId });
             }
 
             if (profile == null)
@@ -295,7 +295,7 @@ namespace SFServer.UI.Controllers
                 TempData["Error"] = "Failed to delete user.";
             }
 
-            return RedirectToAction("Index");
+            return RedirectToAction("Index", new { projectId = _project.CurrentProjectId });
         }
         
         
@@ -333,7 +333,7 @@ namespace SFServer.UI.Controllers
             TempData["Success"] = "Wallet updated successfully.";
             // Set the active tab to "wallet"
             TempData["activeTab"] = "wallet";
-            return RedirectToAction("Edit", new { id = model.UserId });
+            return RedirectToAction("Edit", new { projectId = _project.CurrentProjectId, id = model.UserId });
         }
 
         [HttpPost]
@@ -344,7 +344,7 @@ namespace SFServer.UI.Controllers
             {
                 TempData["Error"] = "Invalid inventory data.";
                 TempData["activeTab"] = "inventory";
-                return RedirectToAction("Edit", new { id = model.UserId });
+                return RedirectToAction("Edit", new { projectId = _project.CurrentProjectId, id = model.UserId });
             }
 
             using var client = GetAuthenticatedHttpClient();
@@ -358,7 +358,7 @@ namespace SFServer.UI.Controllers
 
             TempData["Success"] = "Inventory updated successfully.";
             TempData["activeTab"] = "inventory";
-            return RedirectToAction("Edit", new { id = model.UserId });
+            return RedirectToAction("Edit", new { projectId = _project.CurrentProjectId, id = model.UserId });
         }
     }
 }

--- a/SFServer.UI/Controllers/WalletController.cs
+++ b/SFServer.UI/Controllers/WalletController.cs
@@ -15,15 +15,17 @@ namespace SFServer.UI.Controllers
     public class WalletController : Controller
     {
         private readonly IConfiguration _configuration;
+        private readonly ProjectContext _project;
 
-        public WalletController(IConfiguration configuration)
+        public WalletController(IConfiguration configuration, ProjectContext project)
         {
             _configuration = configuration;
+            _project = project;
         }
 
         private HttpClient GetAuthenticatedHttpClient()
         {
-            return User.CreateApiClient(_configuration);
+            return User.CreateApiClient(_configuration, _project.CurrentProjectId);
         }
 
         public async Task<IActionResult> Index()

--- a/SFServer.UI/Controllers/WalletController.cs
+++ b/SFServer.UI/Controllers/WalletController.cs
@@ -56,7 +56,7 @@ namespace SFServer.UI.Controllers
                 TempData["Error"] = $"Failed to update wallet item: {response}";
             }
 
-            return RedirectToAction("Index");
+            return RedirectToAction("Index", new { projectId = _project.CurrentProjectId });
         }
     }
 }

--- a/SFServer.UI/Filters/ProjectContextFilter.cs
+++ b/SFServer.UI/Filters/ProjectContextFilter.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.Extensions.Configuration;
+using SFServer.Shared.Server.Project;
+
+namespace SFServer.UI.Filters
+{
+    public class ProjectContextFilter : IAsyncActionFilter
+    {
+        private readonly IConfiguration _config;
+        private readonly ProjectContext _context;
+
+        public ProjectContextFilter(IConfiguration config, ProjectContext context)
+        {
+            _config = config;
+            _context = context;
+        }
+
+        public async Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)
+        {
+            // Read project id from route if provided
+            if (context.RouteData.Values.TryGetValue("projectId", out var value) &&
+                Guid.TryParse(value?.ToString(), out var id))
+            {
+                _context.CurrentProjectId = id;
+            }
+
+            if (context.HttpContext.User.Identity?.IsAuthenticated == true)
+            {
+                using var client = context.HttpContext.User.CreateApiClient(_config);
+                var projects = await client.GetFromMessagePackAsync<List<ProjectInfo>>("Projects") ?? new();
+                if (projects.Count > 0)
+                {
+                    var match = projects.FirstOrDefault(p => p.Id == _context.CurrentProjectId);
+                    if (match == null)
+                    {
+                        match = projects.First();
+                    }
+                    _context.CurrentProjectId = match.Id;
+                    _context.CurrentProjectName = match.Name;
+                }
+                else
+                {
+                    _context.CurrentProjectId = Guid.Empty;
+                    _context.CurrentProjectName = string.Empty;
+                }
+            }
+
+            await next();
+        }
+    }
+}

--- a/SFServer.UI/GlobalSettingsService.cs
+++ b/SFServer.UI/GlobalSettingsService.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using SFServer.Shared.Server.Settings;
+
+namespace SFServer.UI
+{
+    public class GlobalSettingsService
+    {
+        private readonly IHttpClientFactory _factory;
+        private readonly IConfiguration _configuration;
+        private GlobalSettings _cached;
+
+        public GlobalSettingsService(IHttpClientFactory factory, IConfiguration configuration)
+        {
+            _factory = factory;
+            _configuration = configuration;
+        }
+
+        public async Task<GlobalSettings> GetSettingsAsync()
+        {
+            if (_cached != null)
+                return _cached;
+
+            var client = _factory.CreateClient("api");
+            _cached = await client.GetFromMessagePackAsync<GlobalSettings>("GlobalSettings") ?? new GlobalSettings();
+            return _cached;
+        }
+
+        public void UpdateCache(GlobalSettings settings)
+        {
+            _cached = settings;
+        }
+    }
+}

--- a/SFServer.UI/HttpClientMessagePackExtensions.cs
+++ b/SFServer.UI/HttpClientMessagePackExtensions.cs
@@ -22,7 +22,10 @@ namespace SFServer.UI
 
         public static HttpClient CreateApiClient(this ClaimsPrincipal user, IConfiguration config, Guid projectId = default)
         {
-            var client = new HttpClient { BaseAddress = new Uri(config["API_BASE_URL"]) };
+            var baseUrl = config["API_BASE_URL"].TrimEnd('/') + "/";
+            if (projectId != Guid.Empty)
+                baseUrl += projectId.ToString() + "/";
+            var client = new HttpClient { BaseAddress = new Uri(baseUrl) };
 
             var token = user.FindFirst("JwtToken")?.Value;
             if (!string.IsNullOrEmpty(token))
@@ -37,10 +40,6 @@ namespace SFServer.UI
                 Console.WriteLine("UserId" + userId);
             }
 
-            if (projectId != Guid.Empty)
-            {
-                client.DefaultRequestHeaders.Add("ProjectId", projectId.ToString());
-            }
             return client;
         }
 

--- a/SFServer.UI/HttpClientMessagePackExtensions.cs
+++ b/SFServer.UI/HttpClientMessagePackExtensions.cs
@@ -20,7 +20,7 @@ namespace SFServer.UI
         // Configure MessagePack options to use ContractlessStandardResolver.
         private static readonly MemoryPackSerializerOptions DefaultOptions = MemoryPackSerializerOptions.Default;
 
-        public static HttpClient CreateApiClient(this ClaimsPrincipal user, IConfiguration config)
+        public static HttpClient CreateApiClient(this ClaimsPrincipal user, IConfiguration config, Guid projectId = default)
         {
             var client = new HttpClient { BaseAddress = new Uri(config["API_BASE_URL"]) };
 
@@ -37,6 +37,10 @@ namespace SFServer.UI
                 Console.WriteLine("UserId" + userId);
             }
 
+            if (projectId != Guid.Empty)
+            {
+                client.DefaultRequestHeaders.Add("ProjectId", projectId.ToString());
+            }
             return client;
         }
 

--- a/SFServer.UI/Models/GlobalSettingsViewModel.cs
+++ b/SFServer.UI/Models/GlobalSettingsViewModel.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Collections.Generic;
+using SFServer.Shared.Server.Admin;
+using SFServer.Shared.Server.Project;
+using SFServer.Shared.Server.Settings;
+
+namespace SFServer.UI.Models
+{
+    public class GlobalSettingsViewModel
+    {
+        public GlobalSettings Settings { get; set; } = new();
+        public List<Administrator> Administrators { get; set; } = new();
+        public List<ProjectInfo> Projects { get; set; } = new();
+    }
+}

--- a/SFServer.UI/Models/ProjectSettingsViewModel.cs
+++ b/SFServer.UI/Models/ProjectSettingsViewModel.cs
@@ -3,7 +3,7 @@ using System.ComponentModel.DataAnnotations;
 
 namespace SFServer.UI.Models
 {
-    public class ServerSettingsViewModel
+    public class ProjectSettingsViewModel
     {
         public Guid Id { get; set; }
 

--- a/SFServer.UI/Models/ProjectSettingsViewModel.cs
+++ b/SFServer.UI/Models/ProjectSettingsViewModel.cs
@@ -7,12 +7,6 @@ namespace SFServer.UI.Models
     {
         public Guid Id { get; set; }
 
-        [Display(Name = "Server Title")]
-        public string ServerTitle { get; set; } = string.Empty;
-
-        [Display(Name = "Copyright")]
-        public string ServerCopyright { get; set; } = string.Empty;
-
         [Display(Name = "Google Client ID")]
         public string GoogleClientId { get; set; } = string.Empty;
 

--- a/SFServer.UI/Models/ProjectSettingsViewModel.cs
+++ b/SFServer.UI/Models/ProjectSettingsViewModel.cs
@@ -17,5 +17,8 @@ namespace SFServer.UI.Models
 
         [Display(Name = "Service Account JSON")]
         public string GoogleServiceAccountJson { get; set; } = string.Empty;
+
+        [Display(Name = "Bundle ID")]
+        public string BundleId { get; set; } = string.Empty;
     }
 }

--- a/SFServer.UI/Models/UserProfiles/CreateUserProfileViewModel.cs
+++ b/SFServer.UI/Models/UserProfiles/CreateUserProfileViewModel.cs
@@ -11,8 +11,6 @@ namespace SFServer.UI.Models.UserProfiles
         [EmailAddress]
         public string Email { get; set; }
 
-        [Required, DataType(DataType.Password)]
-        public string Password { get; set; }
 
         [Required]
         public UserRole Role { get; set; } = UserRole.User;

--- a/SFServer.UI/Models/UserProfiles/EditUserProfileViewModel.cs
+++ b/SFServer.UI/Models/UserProfiles/EditUserProfileViewModel.cs
@@ -24,14 +24,6 @@ namespace SFServer.UI.Models.UserProfiles
     
         public string FacebookId { get; set; }
 
-        // New properties for password change
-        [DataType(DataType.Password)]
-        public string NewPassword { get; set; }
-    
-    
-        [DataType(DataType.Password)]
-        [Compare("NewPassword", ErrorMessage = "Passwords do not match.")]
-        public string ConfirmPassword { get; set; }
     
         public List<WalletItemViewModel> WalletItems { get; set; } = new() { };
     

--- a/SFServer.UI/Pages/Inventory/Create.cshtml
+++ b/SFServer.UI/Pages/Inventory/Create.cshtml
@@ -1,4 +1,4 @@
-@page
+@page "/{projectId:guid}/Inventory/Create"
 @using SFServer.Shared.Server.Inventory
 @model SFServer.UI.Pages.Inventory.CreateInventoryItemModel
 @{

--- a/SFServer.UI/Pages/Inventory/Create.cshtml.cs
+++ b/SFServer.UI/Pages/Inventory/Create.cshtml.cs
@@ -13,10 +13,12 @@ namespace SFServer.UI.Pages.Inventory
     public class CreateInventoryItemModel : PageModel
     {
         private readonly IConfiguration _config;
+        private readonly ProjectContext _project;
 
-        public CreateInventoryItemModel(IConfiguration config)
+        public CreateInventoryItemModel(IConfiguration config, ProjectContext project)
         {
             _config = config;
+            _project = project;
         }
 
         [BindProperty]
@@ -27,7 +29,7 @@ namespace SFServer.UI.Pages.Inventory
 
         private HttpClient GetClient()
         {
-            return User.CreateApiClient(_config);
+            return User.CreateApiClient(_config, _project.CurrentProjectId);
         }
 
         public void OnGet()

--- a/SFServer.UI/Pages/Inventory/Create.cshtml.cs
+++ b/SFServer.UI/Pages/Inventory/Create.cshtml.cs
@@ -15,6 +15,9 @@ namespace SFServer.UI.Pages.Inventory
         private readonly IConfiguration _config;
         private readonly ProjectContext _project;
 
+        [BindProperty(SupportsGet = true)]
+        public Guid projectId { get; set; }
+
         public CreateInventoryItemModel(IConfiguration config, ProjectContext project)
         {
             _config = config;
@@ -52,7 +55,7 @@ namespace SFServer.UI.Pages.Inventory
                 ModelState.AddModelError(string.Empty, "Failed to create item");
                 return Page();
             }
-            return RedirectToPage("/Inventory/Index");
+            return RedirectToPage("/Inventory/Index", new { projectId });
         }
     }
 }

--- a/SFServer.UI/Pages/Inventory/Edit.cshtml
+++ b/SFServer.UI/Pages/Inventory/Edit.cshtml
@@ -1,4 +1,4 @@
-@page "{id:guid}"
+@page "/{projectId:guid}/Inventory/Edit/{id:guid}"
 @using SFServer.Shared.Server.Inventory
 @model SFServer.UI.Pages.Inventory.EditInventoryItemModel
 @{

--- a/SFServer.UI/Pages/Inventory/Edit.cshtml.cs
+++ b/SFServer.UI/Pages/Inventory/Edit.cshtml.cs
@@ -16,6 +16,9 @@ namespace SFServer.UI.Pages.Inventory
         private readonly IConfiguration _config;
         private readonly ProjectContext _project;
 
+        [BindProperty(SupportsGet = true)]
+        public Guid projectId { get; set; }
+
         public EditInventoryItemModel(IConfiguration config, ProjectContext project)
         {
             _config = config;
@@ -56,7 +59,7 @@ namespace SFServer.UI.Pages.Inventory
             }
 
             await http.PutAsMessagePackAsync($"Inventory/{Item.Id}", Item);
-            return RedirectToPage("/Inventory/Index");
+            return RedirectToPage("/Inventory/Index", new { projectId });
         }
     }
 }

--- a/SFServer.UI/Pages/Inventory/Edit.cshtml.cs
+++ b/SFServer.UI/Pages/Inventory/Edit.cshtml.cs
@@ -14,10 +14,12 @@ namespace SFServer.UI.Pages.Inventory
     public class EditInventoryItemModel : PageModel
     {
         private readonly IConfiguration _config;
+        private readonly ProjectContext _project;
 
-        public EditInventoryItemModel(IConfiguration config)
+        public EditInventoryItemModel(IConfiguration config, ProjectContext project)
         {
             _config = config;
+            _project = project;
         }
 
         [BindProperty]
@@ -28,7 +30,7 @@ namespace SFServer.UI.Pages.Inventory
 
         private HttpClient GetClient()
         {
-            return User.CreateApiClient(_config);
+            return User.CreateApiClient(_config, _project.CurrentProjectId);
         }
 
         public async Task OnGetAsync(Guid id)

--- a/SFServer.UI/Pages/Inventory/Index.cshtml
+++ b/SFServer.UI/Pages/Inventory/Index.cshtml
@@ -1,4 +1,4 @@
-@page
+@page "/{projectId:guid}/Inventory"
 @model SFServer.UI.Pages.Inventory.InventoryPageModel
 @{
     ViewData["Title"] = "Inventory";
@@ -6,7 +6,7 @@
 
 <h1>Inventory</h1>
 <p>
-    <a class="btn btn-primary" asp-page="/Inventory/Create">Add Item</a>
+    <a class="btn btn-primary" asp-page="/Inventory/Create" asp-route-projectId="@Model.projectId">Add Item</a>
 </p>
 <table class="table">
     <thead>
@@ -29,8 +29,8 @@
             <td>@item.Price</td>
             <td>@item.ProductId</td>
             <td>
-                <a class="btn btn-sm btn-secondary" asp-page="/Inventory/Edit" asp-route-id="@item.Id">Edit</a>
-                <form method="post" asp-page-handler="Delete" asp-route-id="@item.Id" class="d-inline">
+                <a class="btn btn-sm btn-secondary" asp-page="/Inventory/Edit" asp-route-projectId="@Model.projectId" asp-route-id="@item.Id">Edit</a>
+                <form method="post" asp-page-handler="Delete" asp-route-projectId="@Model.projectId" asp-route-id="@item.Id" class="d-inline">
                     <button type="submit" class="btn btn-sm btn-danger" onclick="return confirm('Delete this item?');">Remove</button>
                 </form>
             </td>

--- a/SFServer.UI/Pages/Inventory/Index.cshtml.cs
+++ b/SFServer.UI/Pages/Inventory/Index.cshtml.cs
@@ -13,17 +13,19 @@ namespace SFServer.UI.Pages.Inventory
     public class InventoryPageModel : PageModel
     {
         private readonly IConfiguration _config;
+        private readonly ProjectContext _project;
 
-        public InventoryPageModel(IConfiguration config)
+        public InventoryPageModel(IConfiguration config, ProjectContext project)
         {
             _config = config;
+            _project = project;
         }
 
         public List<InventoryItem> Items { get; set; } = new();
 
         private HttpClient GetClient()
         {
-            return User.CreateApiClient(_config);
+            return User.CreateApiClient(_config, _project.CurrentProjectId);
         }
 
         public async Task OnGetAsync()

--- a/SFServer.UI/Pages/Inventory/Index.cshtml.cs
+++ b/SFServer.UI/Pages/Inventory/Index.cshtml.cs
@@ -15,6 +15,9 @@ namespace SFServer.UI.Pages.Inventory
         private readonly IConfiguration _config;
         private readonly ProjectContext _project;
 
+        [BindProperty(SupportsGet = true)]
+        public Guid projectId { get; set; }
+
         public InventoryPageModel(IConfiguration config, ProjectContext project)
         {
             _config = config;
@@ -38,7 +41,7 @@ namespace SFServer.UI.Pages.Inventory
         {
             using var http = GetClient();
             await http.DeleteAsync($"Inventory/{id}");
-            return RedirectToPage();
+            return RedirectToPage(new { projectId = projectId });
         }
     }
 }

--- a/SFServer.UI/Program.cs
+++ b/SFServer.UI/Program.cs
@@ -71,7 +71,8 @@ app.UseRouting();
 app.UseAuthentication();
 app.UseAuthorization();
 
-app.MapControllerRoute(name: "default", pattern: "{controller=Home}/{action=Index}/{id?}");
+app.MapControllerRoute(name: "project", pattern: "{projectId:guid}/{controller=Home}/{action=Index}/{id?}");
+app.MapControllerRoute(name: "default", pattern: "{controller=Account}/{action=Login}/{id?}");
 app.MapRazorPages();
 
 app.Run();

--- a/SFServer.UI/Program.cs
+++ b/SFServer.UI/Program.cs
@@ -49,7 +49,8 @@ builder.Services.AddHttpClient("api", c =>
 {
     c.BaseAddress = new Uri(builder.Configuration["API_BASE_URL"]);
 });
-builder.Services.AddSingleton<ServerSettingsService>();
+builder.Services.AddSingleton<ProjectSettingsService>();
+builder.Services.AddSingleton<GlobalSettingsService>();
 builder.Services.AddSingleton<ProjectContext>();
 
 var app = builder.Build();

--- a/SFServer.UI/Program.cs
+++ b/SFServer.UI/Program.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using SFServer.UI;
+using SFServer.UI.Filters;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -42,6 +43,7 @@ builder.Services.AddAuthorization();
 builder.Services.AddControllersWithViews(options =>
 {
     options.Filters.Add(new AuthorizeFilter());
+    options.Filters.Add<ProjectContextFilter>();
 });
 builder.Services.AddRazorPages();
 
@@ -52,6 +54,7 @@ builder.Services.AddHttpClient("api", c =>
 builder.Services.AddSingleton<ProjectSettingsService>();
 builder.Services.AddSingleton<GlobalSettingsService>();
 builder.Services.AddSingleton<ProjectContext>();
+builder.Services.AddScoped<ProjectContextFilter>();
 
 var app = builder.Build();
 

--- a/SFServer.UI/Program.cs
+++ b/SFServer.UI/Program.cs
@@ -50,6 +50,7 @@ builder.Services.AddHttpClient("api", c =>
     c.BaseAddress = new Uri(builder.Configuration["API_BASE_URL"]);
 });
 builder.Services.AddSingleton<ServerSettingsService>();
+builder.Services.AddSingleton<ProjectContext>();
 
 var app = builder.Build();
 

--- a/SFServer.UI/ProjectContext.cs
+++ b/SFServer.UI/ProjectContext.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace SFServer.UI;
+
+public class ProjectContext
+{
+    public Guid CurrentProjectId { get; set; }
+    public string CurrentProjectName { get; set; } = string.Empty;
+}

--- a/SFServer.UI/ProjectSettingsService.cs
+++ b/SFServer.UI/ProjectSettingsService.cs
@@ -6,22 +6,22 @@ using SFServer.Shared.Server.Settings;
 
 namespace SFServer.UI
 {
-    public class ServerSettingsService
+    public class ProjectSettingsService
     {
         private readonly IHttpClientFactory _factory;
         private readonly IConfiguration _configuration;
         private readonly ProjectContext _project;
-        private ServerSettings _cached;
+        private ProjectSettings _cached;
         private Guid _cachedProjectId;
 
-        public ServerSettingsService(IHttpClientFactory factory, IConfiguration configuration, ProjectContext project)
+        public ProjectSettingsService(IHttpClientFactory factory, IConfiguration configuration, ProjectContext project)
         {
             _factory = factory;
             _configuration = configuration;
             _project = project;
         }
 
-        public async Task<ServerSettings> GetSettingsAsync()
+        public async Task<ProjectSettings> GetSettingsAsync()
         {
             if (_cached != null && _cachedProjectId == _project.CurrentProjectId)
                 return _cached;
@@ -30,12 +30,12 @@ namespace SFServer.UI
             if (_project.CurrentProjectId != Guid.Empty)
                 client.BaseAddress = new Uri(client.BaseAddress.ToString().TrimEnd('/') + "/" + _project.CurrentProjectId + "/");
 
-            _cached = await client.GetFromMessagePackAsync<ServerSettings>("ServerSettings") ?? new ServerSettings();
+            _cached = await client.GetFromMessagePackAsync<ProjectSettings>("ProjectSettings") ?? new ProjectSettings();
             _cachedProjectId = _project.CurrentProjectId;
             return _cached;
         }
 
-        public void UpdateCache(ServerSettings settings)
+        public void UpdateCache(ProjectSettings settings)
         {
             _cached = settings;
             _cachedProjectId = _project.CurrentProjectId;

--- a/SFServer.UI/ServerSettingsService.cs
+++ b/SFServer.UI/ServerSettingsService.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
@@ -9,26 +10,35 @@ namespace SFServer.UI
     {
         private readonly IHttpClientFactory _factory;
         private readonly IConfiguration _configuration;
+        private readonly ProjectContext _project;
         private ServerSettings _cached;
+        private Guid _cachedProjectId;
 
-        public ServerSettingsService(IHttpClientFactory factory, IConfiguration configuration)
+        public ServerSettingsService(IHttpClientFactory factory, IConfiguration configuration, ProjectContext project)
         {
             _factory = factory;
             _configuration = configuration;
+            _project = project;
         }
 
         public async Task<ServerSettings> GetSettingsAsync()
         {
-            if (_cached != null)
+            if (_cached != null && _cachedProjectId == _project.CurrentProjectId)
                 return _cached;
+
             var client = _factory.CreateClient("api");
+            if (_project.CurrentProjectId != Guid.Empty)
+                client.DefaultRequestHeaders.Add("ProjectId", _project.CurrentProjectId.ToString());
+
             _cached = await client.GetFromMessagePackAsync<ServerSettings>("ServerSettings") ?? new ServerSettings();
+            _cachedProjectId = _project.CurrentProjectId;
             return _cached;
         }
 
         public void UpdateCache(ServerSettings settings)
         {
             _cached = settings;
+            _cachedProjectId = _project.CurrentProjectId;
         }
     }
 }

--- a/SFServer.UI/ServerSettingsService.cs
+++ b/SFServer.UI/ServerSettingsService.cs
@@ -28,7 +28,7 @@ namespace SFServer.UI
 
             var client = _factory.CreateClient("api");
             if (_project.CurrentProjectId != Guid.Empty)
-                client.DefaultRequestHeaders.Add("ProjectId", _project.CurrentProjectId.ToString());
+                client.BaseAddress = new Uri(client.BaseAddress.ToString().TrimEnd('/') + "/" + _project.CurrentProjectId + "/");
 
             _cached = await client.GetFromMessagePackAsync<ServerSettings>("ServerSettings") ?? new ServerSettings();
             _cachedProjectId = _project.CurrentProjectId;

--- a/SFServer.UI/Views/Administrators/Index.cshtml
+++ b/SFServer.UI/Views/Administrators/Index.cshtml
@@ -36,13 +36,10 @@
             <td>@a.Username</td>
             <td>@a.Email</td>
             <td>
-                @if (a.Id != Guid.Empty)
-                {
-                    <form asp-action="Delete" method="post" class="d-inline">
-                        <input type="hidden" name="id" value="@a.Id" />
-                        <button type="submit" class="btn btn-danger btn-sm">Delete</button>
-                    </form>
-                }
+                <form asp-action="Delete" method="post" class="d-inline">
+                    <input type="hidden" name="id" value="@a.Id" />
+                    <button type="submit" class="btn btn-danger btn-sm">Delete</button>
+                </form>
             </td>
         </tr>
 }

--- a/SFServer.UI/Views/Administrators/Index.cshtml
+++ b/SFServer.UI/Views/Administrators/Index.cshtml
@@ -1,0 +1,50 @@
+@model List<SFServer.Shared.Server.Admin.Administrator>
+@{
+    ViewData["Title"] = "Administrators";
+}
+<h1>Administrators</h1>
+
+<form asp-action="Create" method="post" class="mb-3">
+    <div class="row g-2">
+        <div class="col-auto">
+            <input type="text" name="Username" class="form-control" placeholder="Username" required />
+        </div>
+        <div class="col-auto">
+            <input type="email" name="Email" class="form-control" placeholder="Email" />
+        </div>
+        <div class="col-auto">
+            <input type="password" name="Password" class="form-control" placeholder="Password" required />
+        </div>
+        <div class="col-auto">
+            <button type="submit" class="btn btn-success">Add</button>
+        </div>
+    </div>
+</form>
+
+<table class="table">
+    <thead>
+        <tr>
+            <th>Username</th>
+            <th>Email</th>
+            <th style="width:150px;">Actions</th>
+        </tr>
+    </thead>
+    <tbody>
+@foreach (var a in Model)
+{
+        <tr>
+            <td>@a.Username</td>
+            <td>@a.Email</td>
+            <td>
+                @if (a.Id != Guid.Empty)
+                {
+                    <form asp-action="Delete" method="post" class="d-inline">
+                        <input type="hidden" name="id" value="@a.Id" />
+                        <button type="submit" class="btn btn-danger btn-sm">Delete</button>
+                    </form>
+                }
+            </td>
+        </tr>
+}
+    </tbody>
+</table>

--- a/SFServer.UI/Views/GlobalSettings/Index.cshtml
+++ b/SFServer.UI/Views/GlobalSettings/Index.cshtml
@@ -72,13 +72,10 @@
                     <td>@a.Username</td>
                     <td>@a.Email</td>
                     <td>
-                        @if (a.Id != Guid.Empty)
-                        {
-                            <form asp-action="DeleteAdmin" method="post" class="d-inline">
-                                <input type="hidden" name="id" value="@a.Id" />
-                                <button type="submit" class="btn btn-danger btn-sm">Delete</button>
-                            </form>
-                        }
+                        <form asp-action="DeleteAdmin" method="post" class="d-inline">
+                            <input type="hidden" name="id" value="@a.Id" />
+                            <button type="submit" class="btn btn-danger btn-sm">Delete</button>
+                        </form>
                     </td>
                 </tr>
             }
@@ -110,13 +107,10 @@
                             <input type="hidden" name="id" value="@p.Id" />
                             <button type="submit" class="btn btn-secondary btn-sm">Settings</button>
                         </form>
-                        @if (p.Id != Guid.Empty)
-                        {
-                            <form asp-action="DeleteProject" method="post" class="d-inline">
-                                <input type="hidden" name="id" value="@p.Id" />
-                                <button type="submit" class="btn btn-danger btn-sm">Delete</button>
-                            </form>
-                        }
+                        <form asp-action="DeleteProject" method="post" class="d-inline">
+                            <input type="hidden" name="id" value="@p.Id" />
+                            <button type="submit" class="btn btn-danger btn-sm">Delete</button>
+                        </form>
                     </td>
                 </tr>
             }

--- a/SFServer.UI/Views/GlobalSettings/Index.cshtml
+++ b/SFServer.UI/Views/GlobalSettings/Index.cshtml
@@ -41,22 +41,6 @@
                 <label asp-for="Settings.ServerCopyright" class="form-label"></label>
                 <input asp-for="Settings.ServerCopyright" class="form-control" />
             </div>
-            <div class="mb-3">
-                <label asp-for="Settings.GoogleClientId" class="form-label"></label>
-                <input asp-for="Settings.GoogleClientId" class="form-control" />
-            </div>
-            <div class="mb-3">
-                <label asp-for="Settings.GoogleClientSecret" class="form-label"></label>
-                <input asp-for="Settings.GoogleClientSecret" class="form-control" />
-            </div>
-            <div class="mb-3">
-                <label asp-for="Settings.ClickHouseConnection" class="form-label"></label>
-                <input asp-for="Settings.ClickHouseConnection" class="form-control" />
-            </div>
-            <div class="mb-3">
-                <label asp-for="Settings.GoogleServiceAccountJson" class="form-label"></label>
-                <textarea asp-for="Settings.GoogleServiceAccountJson" class="form-control" rows="4"></textarea>
-            </div>
             <button type="submit" class="btn btn-primary">Save</button>
         </form>
     </div>
@@ -121,7 +105,11 @@
                             <button type="submit" class="btn btn-primary btn-sm">Rename</button>
                         </form>
                     </td>
-                    <td>
+                    <td class="d-flex gap-2">
+                        <form asp-action="Settings" asp-controller="Projects" method="post">
+                            <input type="hidden" name="id" value="@p.Id" />
+                            <button type="submit" class="btn btn-secondary btn-sm">Settings</button>
+                        </form>
                         @if (p.Id != Guid.Empty)
                         {
                             <form asp-action="DeleteProject" method="post" class="d-inline">

--- a/SFServer.UI/Views/GlobalSettings/Index.cshtml
+++ b/SFServer.UI/Views/GlobalSettings/Index.cshtml
@@ -1,0 +1,142 @@
+@model SFServer.UI.Models.GlobalSettingsViewModel
+@{
+    ViewData["Title"] = "Global Settings";
+}
+
+<h1>Global Settings</h1>
+
+@if (TempData["Success"] != null)
+{
+    <div class="alert alert-success">@TempData["Success"]</div>
+}
+@if (TempData["Error"] != null)
+{
+    <div class="alert alert-danger">@TempData["Error"]</div>
+}
+
+<ul class="nav nav-tabs" id="settingsTabs" role="tablist">
+    <li class="nav-item" role="presentation">
+        <button class="nav-link active" id="general-tab" data-bs-toggle="tab" data-bs-target="#general" type="button" role="tab">General</button>
+    </li>
+    <li class="nav-item" role="presentation">
+        <button class="nav-link" id="admins-tab" data-bs-toggle="tab" data-bs-target="#admins" type="button" role="tab">Administrators</button>
+    </li>
+    <li class="nav-item" role="presentation">
+        <button class="nav-link" id="projects-tab" data-bs-toggle="tab" data-bs-target="#projects" type="button" role="tab">Projects</button>
+    </li>
+    <li class="nav-item" role="presentation">
+        <a class="nav-link" id="audit-tab" href="@Url.Action("Index", "AuditLog")">Audit Log</a>
+    </li>
+</ul>
+<div class="tab-content mt-3" id="settingsTabsContent">
+    <div class="tab-pane fade show active" id="general" role="tabpanel" aria-labelledby="general-tab">
+        <form asp-action="Save" method="post">
+            @Html.AntiForgeryToken()
+            <input type="hidden" asp-for="Settings.Id" />
+            <div class="mb-3">
+                <label asp-for="Settings.ServerTitle" class="form-label"></label>
+                <input asp-for="Settings.ServerTitle" class="form-control" />
+            </div>
+            <div class="mb-3">
+                <label asp-for="Settings.ServerCopyright" class="form-label"></label>
+                <input asp-for="Settings.ServerCopyright" class="form-control" />
+            </div>
+            <div class="mb-3">
+                <label asp-for="Settings.GoogleClientId" class="form-label"></label>
+                <input asp-for="Settings.GoogleClientId" class="form-control" />
+            </div>
+            <div class="mb-3">
+                <label asp-for="Settings.GoogleClientSecret" class="form-label"></label>
+                <input asp-for="Settings.GoogleClientSecret" class="form-control" />
+            </div>
+            <div class="mb-3">
+                <label asp-for="Settings.ClickHouseConnection" class="form-label"></label>
+                <input asp-for="Settings.ClickHouseConnection" class="form-control" />
+            </div>
+            <div class="mb-3">
+                <label asp-for="Settings.GoogleServiceAccountJson" class="form-label"></label>
+                <textarea asp-for="Settings.GoogleServiceAccountJson" class="form-control" rows="4"></textarea>
+            </div>
+            <button type="submit" class="btn btn-primary">Save</button>
+        </form>
+    </div>
+    <div class="tab-pane fade" id="admins" role="tabpanel" aria-labelledby="admins-tab">
+        <form asp-action="AddAdmin" method="post" class="mb-3">
+            <div class="row g-2">
+                <div class="col-auto">
+                    <input type="text" name="Username" class="form-control" placeholder="Username" required />
+                </div>
+                <div class="col-auto">
+                    <input type="email" name="Email" class="form-control" placeholder="Email" />
+                </div>
+                <div class="col-auto">
+                    <input type="password" name="Password" class="form-control" placeholder="Password" required />
+                </div>
+                <div class="col-auto">
+                    <button type="submit" class="btn btn-success">Add</button>
+                </div>
+            </div>
+        </form>
+        <table class="table">
+            <thead>
+                <tr><th>Username</th><th>Email</th><th style="width:150px;">Actions</th></tr>
+            </thead>
+            <tbody>
+            @foreach (var a in Model.Administrators)
+            {
+                <tr>
+                    <td>@a.Username</td>
+                    <td>@a.Email</td>
+                    <td>
+                        @if (a.Id != Guid.Empty)
+                        {
+                            <form asp-action="DeleteAdmin" method="post" class="d-inline">
+                                <input type="hidden" name="id" value="@a.Id" />
+                                <button type="submit" class="btn btn-danger btn-sm">Delete</button>
+                            </form>
+                        }
+                    </td>
+                </tr>
+            }
+            </tbody>
+        </table>
+    </div>
+    <div class="tab-pane fade" id="projects" role="tabpanel" aria-labelledby="projects-tab">
+        <form asp-action="CreateProject" method="post" class="mb-3 d-flex">
+            <input type="text" name="name" class="form-control me-2" placeholder="Project Name" required />
+            <button type="submit" class="btn btn-success">Add</button>
+        </form>
+        <table class="table">
+            <thead>
+                <tr><th>Name</th><th style="width:150px;">Actions</th></tr>
+            </thead>
+            <tbody>
+            @foreach (var p in Model.Projects)
+            {
+                <tr>
+                    <td>
+                        <form asp-action="RenameProject" method="post" class="d-flex">
+                            <input type="hidden" name="id" value="@p.Id" />
+                            <input type="text" name="name" value="@p.Name" class="form-control form-control-sm me-2" />
+                            <button type="submit" class="btn btn-primary btn-sm">Rename</button>
+                        </form>
+                    </td>
+                    <td>
+                        @if (p.Id != Guid.Empty)
+                        {
+                            <form asp-action="DeleteProject" method="post" class="d-inline">
+                                <input type="hidden" name="id" value="@p.Id" />
+                                <button type="submit" class="btn btn-danger btn-sm">Delete</button>
+                            </form>
+                        }
+                    </td>
+                </tr>
+            }
+            </tbody>
+        </table>
+    </div>
+</div>
+
+@section Scripts {
+    @{ await Html.RenderPartialAsync("_ValidationScriptsPartial"); }
+}

--- a/SFServer.UI/Views/ProjectSettings/Index.cshtml
+++ b/SFServer.UI/Views/ProjectSettings/Index.cshtml
@@ -1,15 +1,8 @@
-@model SFServer.UI.Models.ServerSettingsViewModel
+@model SFServer.UI.Models.ProjectSettingsViewModel
 @{
-    ViewData["Title"] = "Server Settings";
+    ViewData["Title"] = "Project Settings";
 }
-
-<h1>Server Settings</h1>
-
-<div class="mb-3">
-    <a asp-controller="AuditLog" asp-action="Index" class="btn btn-outline-secondary btn-sm">
-        <i class="bi bi-clipboard-data"></i> View Audit Log
-    </a>
-</div>
+<h1>Project Settings</h1>
 
 @if (TempData["Success"] != null)
 {

--- a/SFServer.UI/Views/ProjectSettings/Index.cshtml
+++ b/SFServer.UI/Views/ProjectSettings/Index.cshtml
@@ -29,6 +29,10 @@
         <input asp-for="ClickHouseConnection" class="form-control" />
     </div>
     <div class="mb-3">
+        <label asp-for="BundleId" class="form-label"></label>
+        <input asp-for="BundleId" class="form-control" />
+    </div>
+    <div class="mb-3">
         <label asp-for="GoogleServiceAccountJson" class="form-label"></label>
         <textarea asp-for="GoogleServiceAccountJson" class="form-control" rows="4"></textarea>
     </div>

--- a/SFServer.UI/Views/ProjectSettings/Index.cshtml
+++ b/SFServer.UI/Views/ProjectSettings/Index.cshtml
@@ -17,14 +17,6 @@
     @Html.AntiForgeryToken()
     <input type="hidden" asp-for="Id" />
     <div class="mb-3">
-        <label asp-for="ServerTitle" class="form-label"></label>
-        <input asp-for="ServerTitle" class="form-control" />
-    </div>
-    <div class="mb-3">
-        <label asp-for="ServerCopyright" class="form-label"></label>
-        <input asp-for="ServerCopyright" class="form-control" />
-    </div>
-    <div class="mb-3">
         <label asp-for="GoogleClientId" class="form-label"></label>
         <input asp-for="GoogleClientId" class="form-control" />
     </div>

--- a/SFServer.UI/Views/Projects/Index.cshtml
+++ b/SFServer.UI/Views/Projects/Index.cshtml
@@ -1,0 +1,42 @@
+@model List<SFServer.Shared.Server.Project.ProjectInfo>
+@using Microsoft.AspNetCore.Mvc.Rendering
+@{
+    ViewData["Title"] = "Projects";
+}
+<h1>Projects</h1>
+
+<form asp-action="Create" method="post" class="mb-3">
+    <div class="input-group">
+        <input type="text" name="name" class="form-control" placeholder="Project name" required />
+        <button type="submit" class="btn btn-success">Add</button>
+    </div>
+</form>
+
+<table class="table">
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th style="width:150px;">Actions</th>
+        </tr>
+    </thead>
+    <tbody>
+@foreach (var p in Model)
+{
+        <tr>
+            <td>@p.Name</td>
+            <td>
+                <form asp-action="Delete" method="post" class="d-inline">
+                    <input type="hidden" name="id" value="@p.Id" />
+                    <button type="submit" class="btn btn-danger btn-sm">Delete</button>
+                </form>
+            </td>
+        </tr>
+}
+    </tbody>
+</table>
+
+<form asp-action="Select" method="post" class="mt-3">
+    <select name="id" class="form-select" asp-items="@(new SelectList(Model, "Id", "Name", null))"></select>
+    <button type="submit" class="btn btn-primary mt-2">Select</button>
+</form>
+

--- a/SFServer.UI/Views/Projects/Index.cshtml
+++ b/SFServer.UI/Views/Projects/Index.cshtml
@@ -35,13 +35,10 @@
                     <input type="hidden" name="id" value="@p.Id" />
                     <button type="submit" class="btn btn-secondary btn-sm">Settings</button>
                 </form>
-                @if (p.Id != Guid.Empty)
-                {
-                    <form asp-action="Delete" method="post" class="d-inline">
-                        <input type="hidden" name="id" value="@p.Id" />
-                        <button type="submit" class="btn btn-danger btn-sm">Delete</button>
-                    </form>
-                }
+                <form asp-action="Delete" method="post" class="d-inline">
+                    <input type="hidden" name="id" value="@p.Id" />
+                    <button type="submit" class="btn btn-danger btn-sm">Delete</button>
+                </form>
             </td>
         </tr>
 }

--- a/SFServer.UI/Views/Projects/Index.cshtml
+++ b/SFServer.UI/Views/Projects/Index.cshtml
@@ -16,19 +16,28 @@
     <thead>
         <tr>
             <th>Name</th>
-            <th style="width:150px;">Actions</th>
+            <th style="width:200px;">Actions</th>
         </tr>
     </thead>
     <tbody>
 @foreach (var p in Model)
 {
         <tr>
-            <td>@p.Name</td>
             <td>
-                <form asp-action="Delete" method="post" class="d-inline">
+                <form asp-action="Rename" method="post" class="d-flex">
                     <input type="hidden" name="id" value="@p.Id" />
-                    <button type="submit" class="btn btn-danger btn-sm">Delete</button>
+                    <input type="text" name="name" value="@p.Name" class="form-control form-control-sm me-2" />
+                    <button type="submit" class="btn btn-primary btn-sm">Rename</button>
                 </form>
+            </td>
+            <td>
+                @if (p.Id != Guid.Empty)
+                {
+                    <form asp-action="Delete" method="post" class="d-inline">
+                        <input type="hidden" name="id" value="@p.Id" />
+                        <button type="submit" class="btn btn-danger btn-sm">Delete</button>
+                    </form>
+                }
             </td>
         </tr>
 }

--- a/SFServer.UI/Views/Projects/Index.cshtml
+++ b/SFServer.UI/Views/Projects/Index.cshtml
@@ -30,7 +30,11 @@
                     <button type="submit" class="btn btn-primary btn-sm">Rename</button>
                 </form>
             </td>
-            <td>
+            <td class="d-flex gap-2">
+                <form asp-action="Settings" method="post">
+                    <input type="hidden" name="id" value="@p.Id" />
+                    <button type="submit" class="btn btn-secondary btn-sm">Settings</button>
+                </form>
                 @if (p.Id != Guid.Empty)
                 {
                     <form asp-action="Delete" method="post" class="d-inline">

--- a/SFServer.UI/Views/Shared/_Layout.cshtml
+++ b/SFServer.UI/Views/Shared/_Layout.cshtml
@@ -3,11 +3,11 @@
 @using SFServer.Shared.Server.UserProfile
 @inject IConfiguration Configuration
 @using SFServer.UI
-@inject ServerSettingsService SettingsService
+@inject GlobalSettingsService GlobalSettingsService
 @inject ProjectContext ProjectContext
 @using SFServer.Shared.Server.Project
 @{
-    var settings = await SettingsService.GetSettingsAsync();
+    var settings = await GlobalSettingsService.GetSettingsAsync();
     var projects = new List<ProjectInfo>();
     if (User.Identity?.IsAuthenticated == true)
     {
@@ -70,16 +70,6 @@
                         <li class="nav-item">
                             <a class="nav-link text-dark" asp-controller="Economy" asp-action="Index" asp-route-projectId="@ProjectContext.CurrentProjectId">
                                 <i class="bi bi-currency-dollar"></i> Economy
-                            </a>
-                        </li>
-                        <li class="nav-item">
-                            <a class="nav-link text-dark" asp-controller="Projects" asp-action="Index" asp-route-projectId="@ProjectContext.CurrentProjectId">
-                                <i class="bi bi-collection"></i> Projects
-                            </a>
-                        </li>
-                        <li class="nav-item">
-                            <a class="nav-link text-dark" asp-controller="Administrators" asp-action="Index" asp-route-projectId="@ProjectContext.CurrentProjectId">
-                                <i class="bi bi-shield-lock"></i> Admins
                             </a>
                         </li>
                         <li class="nav-item">
@@ -162,8 +152,8 @@
 
         @if (User.IsInRole("Admin"))
         {
-            <a class="btn btn-outline-secondary btn-sm" asp-controller="ServerSettings" asp-action="Index" asp-route-projectId="@ProjectContext.CurrentProjectId">
-                <i class="bi bi-gear"></i> Server Settings
+            <a class="btn btn-outline-secondary btn-sm" asp-controller="GlobalSettings" asp-action="Index">
+                <i class="bi bi-gear"></i> Global Settings
             </a>
         }
 

--- a/SFServer.UI/Views/Shared/_Layout.cshtml
+++ b/SFServer.UI/Views/Shared/_Layout.cshtml
@@ -4,8 +4,16 @@
 @inject IConfiguration Configuration
 @using SFServer.UI
 @inject ServerSettingsService SettingsService
+@inject ProjectContext ProjectContext
+@using SFServer.Shared.Server.Project
 @{
     var settings = await SettingsService.GetSettingsAsync();
+    var projects = new List<ProjectInfo>();
+    if (User.Identity?.IsAuthenticated == true)
+    {
+        using var client = User.CreateApiClient(Configuration);
+        projects = await client.GetFromMessagePackAsync<List<ProjectInfo>>("Projects") ?? new();
+    }
 }
 
 <!DOCTYPE html>
@@ -61,6 +69,16 @@
                             </a>
                         </li>
                         <li class="nav-item">
+                            <a class="nav-link text-dark" asp-controller="Projects" asp-action="Index">
+                                <i class="bi bi-collection"></i> Projects
+                            </a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link text-dark" asp-controller="Administrators" asp-action="Index">
+                                <i class="bi bi-shield-lock"></i> Admins
+                            </a>
+                        </li>
+                        <li class="nav-item">
                             <a class="nav-link text-dark" asp-page="/Inventory/Index">
                                 <i class="bi bi-box"></i> Inventory
                             </a>
@@ -75,6 +93,14 @@
                 @if (User.Identity?.IsAuthenticated == true)
                 {
                     <div class="d-flex align-items-center">
+                        <form asp-controller="Projects" asp-action="Select" method="post" class="me-3">
+                            <select name="id" class="form-select form-select-sm" onchange="this.form.submit();">
+@foreach (var p in projects)
+{
+                                <option value="@p.Id" selected="@(p.Id == ProjectContext.CurrentProjectId ? "selected" : null)">@p.Name</option>
+}
+                            </select>
+                        </form>
                         <span id="server-time" class="me-3 text-primary fw-bold">--:--:--</span>
                         @{
                             var userId = User.FindFirst("UserId")?.Value;

--- a/SFServer.UI/Views/Shared/_Layout.cshtml
+++ b/SFServer.UI/Views/Shared/_Layout.cshtml
@@ -34,6 +34,10 @@
         if (!apiBaseUrl.endsWith("/")) {
             apiBaseUrl += "/";
         }
+        const currentProject = '@ProjectContext.CurrentProjectId';
+        if (currentProject && currentProject !== '00000000-0000-0000-0000-000000000000') {
+            apiBaseUrl += currentProject + '/';
+        }
         let jwtToken = '@User.FindFirst("JwtToken")?.Value';
     </script>
 </head>
@@ -41,7 +45,7 @@
 <header>
     <nav class="navbar navbar-expand-sm navbar-toggleable-sm navbar-light bg-light border-bottom box-shadow mb-3">
         <div class="container-fluid">
-            <a class="navbar-brand" asp-area="" asp-controller="Home" asp-action="Index">
+            <a class="navbar-brand" asp-area="" asp-controller="Home" asp-action="Index" asp-route-projectId="@ProjectContext.CurrentProjectId">
                 @(settings?.ServerTitle ?? Configuration["SERVER_TITLE"])
             </a>
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target=".navbar-collapse"
@@ -52,39 +56,39 @@
             <div class="collapse navbar-collapse d-sm-inline-flex justify-content-between">
                 <ul class="navbar-nav flex-grow-1">
                     <li class="nav-item">
-                        <a class="nav-link text-dark" asp-area="" asp-controller="Home" asp-action="Index">
+                        <a class="nav-link text-dark" asp-area="" asp-controller="Home" asp-action="Index" asp-route-projectId="@ProjectContext.CurrentProjectId">
                             <i class="bi bi-house-door"></i> Home
                         </a>
                     </li>
                     @if (User.IsInRole(nameof(UserRole.Admin)) || User.IsInRole(nameof(UserRole.Developer)))
                     {
                         <li class="nav-item">
-                            <a class="nav-link text-dark" asp-controller="UserProfiles" asp-action="Index">
+                            <a class="nav-link text-dark" asp-controller="UserProfiles" asp-action="Index" asp-route-projectId="@ProjectContext.CurrentProjectId">
                                 <i class="bi bi-people"></i> Users
                             </a>
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link text-dark" asp-controller="Economy" asp-action="Index">
+                            <a class="nav-link text-dark" asp-controller="Economy" asp-action="Index" asp-route-projectId="@ProjectContext.CurrentProjectId">
                                 <i class="bi bi-currency-dollar"></i> Economy
                             </a>
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link text-dark" asp-controller="Projects" asp-action="Index">
+                            <a class="nav-link text-dark" asp-controller="Projects" asp-action="Index" asp-route-projectId="@ProjectContext.CurrentProjectId">
                                 <i class="bi bi-collection"></i> Projects
                             </a>
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link text-dark" asp-controller="Administrators" asp-action="Index">
+                            <a class="nav-link text-dark" asp-controller="Administrators" asp-action="Index" asp-route-projectId="@ProjectContext.CurrentProjectId">
                                 <i class="bi bi-shield-lock"></i> Admins
                             </a>
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link text-dark" asp-page="/Inventory/Index">
+                            <a class="nav-link text-dark" asp-page="/Inventory/Index" asp-route-projectId="@ProjectContext.CurrentProjectId">
                                 <i class="bi bi-box"></i> Inventory
                             </a>
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link text-dark" asp-controller="Statistics" asp-action="Index">
+                            <a class="nav-link text-dark" asp-controller="Statistics" asp-action="Index" asp-route-projectId="@ProjectContext.CurrentProjectId">
                                 <i class="bi bi-bar-chart"></i> Statistics
                             </a>
                         </li>
@@ -109,28 +113,28 @@
                         @if (User.IsInRole(nameof(UserRole.Admin)))
                         {
                             <a class="me-3 text-muted text-decoration-none" asp-controller="UserProfiles"
-                               asp-action="Edit" asp-route-id="@userId">
+                               asp-action="Edit" asp-route-projectId="@ProjectContext.CurrentProjectId" asp-route-id="@userId">
                                 <i class="bi bi-person-badge"></i> @userName
                             </a>
                         }
                         else if (User.IsInRole(nameof(UserRole.Developer)))
                         {
                             <a class="me-3 text-muted text-decoration-none" asp-controller="UserProfiles"
-                               asp-action="Edit" asp-route-id="@userId">
+                               asp-action="Edit" asp-route-projectId="@ProjectContext.CurrentProjectId" asp-route-id="@userId">
                                 <i class="bi bi-code-slash"></i> @userName
                             </a>
                         }
                         else if (User.IsInRole(nameof(UserRole.User)))
                         {
                             <a class="me-3 text-muted text-decoration-none" asp-controller="UserProfiles"
-                               asp-action="Edit" asp-route-id="@userId">
+                               asp-action="Edit" asp-route-projectId="@ProjectContext.CurrentProjectId" asp-route-id="@userId">
                                 <i class="bi bi-person"></i> @userName
                             </a>
                         }
                         else if (User.IsInRole(nameof(UserRole.Guest)))
                         {
                             <a class="me-3 text-muted text-decoration-none" asp-controller="UserProfiles"
-                               asp-action="Edit" asp-route-id="@userId">
+                               asp-action="Edit" asp-route-projectId="@ProjectContext.CurrentProjectId" asp-route-id="@userId">
                                 <i class="bi bi-person-lines-fill"></i> @userName
                             </a>
                         }
@@ -158,7 +162,7 @@
 
         @if (User.IsInRole("Admin"))
         {
-            <a class="btn btn-outline-secondary btn-sm" asp-controller="ServerSettings" asp-action="Index">
+            <a class="btn btn-outline-secondary btn-sm" asp-controller="ServerSettings" asp-action="Index" asp-route-projectId="@ProjectContext.CurrentProjectId">
                 <i class="bi bi-gear"></i> Server Settings
             </a>
         }

--- a/SFServer.UI/Views/UserProfiles/Create.cshtml
+++ b/SFServer.UI/Views/UserProfiles/Create.cshtml
@@ -16,11 +16,6 @@
         <span asp-validation-for="Email" class="text-danger"></span>
     </div>
     <div class="form-group mb-3">
-        <label asp-for="Password"></label>
-        <input asp-for="Password" type="password" class="form-control" />
-        <span asp-validation-for="Password" class="text-danger"></span>
-    </div>
-    <div class="form-group mb-3">
         <label asp-for="Role"></label>
         <enum-dropdown asp-for="Role" enum-type="@(typeof(UserRole))" exclude="@(new[] { nameof(UserRole.Admin), nameof(UserRole.Guest)  })" />
         <span asp-validation-for="Role" class="text-danger"></span>

--- a/SFServer.UI/Views/UserProfiles/Edit.cshtml
+++ b/SFServer.UI/Views/UserProfiles/Edit.cshtml
@@ -169,21 +169,6 @@
                 }
             </div>
 
-            @if (isAdmin || isSelf)
-            {
-                <h3 class="mt-4">Change Password</h3>
-                <div class="form-group mb-3">
-                    <label asp-for="NewPassword">New Password</label>
-                    <input asp-for="NewPassword" type="password" class="form-control" placeholder="New Password"/>
-                    <span asp-validation-for="NewPassword" class="text-danger"></span>
-                </div>
-                <div class="form-group mb-3">
-                    <label asp-for="ConfirmPassword">Confirm Password</label>
-                    <input asp-for="ConfirmPassword" type="password" class="form-control"
-                           placeholder="Confirm New Password"/>
-                    <span asp-validation-for="ConfirmPassword" class="text-danger"></span>
-                </div>
-            }
 
             <div class="mt-3">
                 <div class="btn-group" role="group" aria-label="Basic example">


### PR DESCRIPTION
## Summary
- introduce `Administrator` entity and API endpoints
- seed a root administrator and use it for dashboard login
- allow admins to manage administrator accounts from the UI
- show "Admins" link in the navigation bar

## Testing
- `dotnet build SFServer.sln -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_6876d41b1f0c832387122457fb6456f4